### PR TITLE
4 changed lines results in a factor of 2 speedup for tensorflow policies

### DIFF
--- a/python/gps/algorithm/policy_opt/policy_opt_tf.py
+++ b/python/gps/algorithm/policy_opt/policy_opt_tf.py
@@ -126,9 +126,7 @@ class PolicyOptTf(PolicyOpt):
             feed_dict = {self.obs_tensor: obs[idx_i],
                          self.action_tensor: tgt_mu[idx_i],
                          self.precision_tensor: tgt_prc[idx_i]}
-            self.solver(feed_dict, self.sess)
-            with tf.device(self.device_string):
-                train_loss = self.sess.run(self.loss_scalar, feed_dict)
+            train_loss = self.solver(feed_dict, self.sess)
 
             average_loss += train_loss
             if i % 500 == 0 and i != 0:

--- a/python/gps/algorithm/policy_opt/tf_utils.py
+++ b/python/gps/algorithm/policy_opt/tf_utils.py
@@ -101,4 +101,6 @@ class TfSolver:
 
     def __call__(self, feed_dict, sess, device_string="/cpu:0"):
         with tf.device(device_string):
-            sess.run(self.solver_op, feed_dict)
+            loss = sess.run([self.loss_scalar, self.solver_op], feed_dict)
+            return loss[0]
+


### PR DESCRIPTION
because now you do not need to compute everything twice.

@cbfinn since this is such a small change that only causes minor alteration in the internals of tensorflow policy opt, I'll just merge it immediately. 
