### PR TITLE
Mjcpy2 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,8 +76,7 @@ python/gps/proto/
 *.pb.cc
 
 # MuJoCo
-src/3rdparty/mjc
-src/3rdparty/mjc2
+src/3rdparty/mjpro
 MUJOCO_LOG.TXT
 
 # Vim

--- a/src/3rdparty/mjcpy2/mjcpy2.cpp
+++ b/src/3rdparty/mjcpy2/mjcpy2.cpp
@@ -150,13 +150,14 @@ bp::object PyMJCWorld2::Step(const bn::ndarray& x, const bn::ndarray& u) {
     // printf("after step+kin: %f\n", m_data->com[0]);
 
     long xdims[1] = {StateSize(m_model)};
-    long odims[1] = {1};  // oout is unused
+    long site_dims[2] = {m_model->nsite, 3};
     bn::ndarray xout = bn::empty(1, xdims, bn::dtype::get_builtin<mjtNum>());
-    bn::ndarray oout = bn::empty(1, odims, bn::dtype::get_builtin<mjtNum>());
+    bn::ndarray site_out = bn::empty(2, site_dims, bn::dtype::get_builtin<mjtNum>());
 
     GetState((mjtNum*)xout.get_data(), m_model, m_data);
+    mju_copy((mjtNum*)site_out.get_data(), m_data->site_xpos, 3*m_model->nsite);
 
-	return bp::make_tuple(xout, oout);
+	return bp::make_tuple(xout, site_out);
 }
 
 


### PR DESCRIPTION
I'm implementing a deep Q-learner which 1) needs to run for many steps/episodes 2) needs to call world.get_data()['site_xpos'] every step to get the cost. Copying over all the data every step was slowing things down, so I modified mjcpy2 to return (state, site_xpos) instead of (state, oout) since no one ever seems to use 'oout'.

It looks like the GPS code only stores world.get_data() to get self._data()['site_xpos'] later, so it might speed things up here too, although I'd imagine trajopt/policyopt is a bigger bottleneck. Feel free to reject this pull request, just wanted to throw this out there. Maybe a better idea is just to add an mjcpy helper method which returns the current (qacc, qvel, site_xpos).
