### PR TITLE
fix gps_main with os.path.abspath call

### DIFF
--- a/python/gps/gps_main.py
+++ b/python/gps/gps_main.py
@@ -276,6 +276,7 @@ def main():
     test_policy_N = args.policy
 
     from gps import __file__ as gps_filepath
+    gps_filepath = os.path.abspath(gps_filepath)
     gps_dir = '/'.join(str.split(gps_filepath, '/')[:-3]) + '/'
     exp_dir = gps_dir + 'experiments/' + exp_name + '/'
     hyperparams_file = exp_dir + 'hyperparams.py'


### PR DESCRIPTION
I had to add this call to get 'mjc_badmm_example' working (didn't try other examples, using Ubuntu 14.04)
