### PR TITLE
Fixes for peg insertion BADMM task

### DIFF
--- a/experiments/mjc_badmm_example/hyperparams.py
+++ b/experiments/mjc_badmm_example/hyperparams.py
@@ -61,8 +61,8 @@ agent = {
     'substeps': 5,
     'conditions': common['conditions'],
     'pos_body_idx': np.array([1]),
-    'pos_body_offset': [np.array([0.0, 0.12, 0]), np.array([0.0, -0.08, 0]),
-                        np.array([-0.2, -0.08, 0]), np.array([-0.2, 0.12, 0])],
+    'pos_body_offset': [np.array([0.1, 0.1, 0]), np.array([0.1, -0.1, 0]),
+                        np.array([-0.1, -0.1, 0]), np.array([-0.1, 0.1, 0])],
     'T': 100,
     'sensor_dims': SENSOR_DIMS,
     'state_include': [JOINT_ANGLES, JOINT_VELOCITIES, END_EFFECTOR_POINTS,
@@ -77,7 +77,8 @@ algorithm = {
     'conditions': common['conditions'],
     'iterations': 12,
     'lg_step_schedule': np.array([1e-4, 1e-3, 1e-2, 1e-2]),
-    'policy_dual_rate': 0.2,
+    'policy_dual_rate': 0.1,
+    'init_pol_wt': 0.01,
     'ent_reg_schedule': np.array([1e-3, 1e-3, 1e-2, 1e-1]),
     'fixed_lg_step': 3,
     'kl_step': 2.0,
@@ -102,13 +103,13 @@ algorithm['init_traj_distr'] = {
 
 torque_cost = {
     'type': CostAction,
-    'wu': 5e-5 / PR2_GAINS,
+    'wu': 1e-3 / PR2_GAINS,
 }
 
 fk_cost = {
     'type': CostFK,
     'target_end_effector': np.array([0.0, 0.3, -0.5, 0.0, 0.3, -0.2]),
-    'wp': np.array([1, 1, 1, 1, 1, 1]),
+    'wp': np.array([2, 2, 1, 2, 2, 1]),
     'l1': 0.1,
     'l2': 10.0,
     'alpha': 1e-5,
@@ -139,7 +140,7 @@ algorithm['dynamics'] = {
         'type': DynamicsPriorGMM,
         'max_clusters': 20,
         'min_samples_per_cluster': 40,
-        'max_samples': 20,
+        'max_samples': 40,
     },
 }
 
@@ -150,14 +151,14 @@ algorithm['traj_opt'] = {
 algorithm['policy_opt'] = {
     'type': PolicyOptCaffe,
     'weights_file_prefix': EXP_DIR + 'policy',
-    'iterations': 2000,
+    'iterations': 4000,
 }
 
 algorithm['policy_prior'] = {
     'type': PolicyPriorGMM,
     'max_clusters': 20,
     'min_samples_per_cluster': 40,
-    'max_samples': 20,
+    'max_samples': 40,
 }
 
 config = {

--- a/python/gps/algorithm/algorithm.py
+++ b/python/gps/algorithm/algorithm.py
@@ -166,11 +166,11 @@ class Algorithm(object):
         counter.
         """
         self.iteration_count += 1
-        self.prev = self.cur
+        self.prev = copy.deepcopy(self.cur)
         self.cur = [IterationData() for _ in range(self.M)]
         for m in range(self.M):
             self.cur[m].traj_info = TrajectoryInfo()
-            self.cur[m].traj_info.dynamics = self.prev[m].traj_info.dynamics
+            self.cur[m].traj_info.dynamics = copy.deepcopy(self.prev[m].traj_info.dynamics)
             self.cur[m].step_mult = self.prev[m].step_mult
             self.cur[m].eta = self.prev[m].eta
             self.cur[m].traj_distr = self.new_traj_distr[m]

--- a/python/gps/algorithm/algorithm_badmm.py
+++ b/python/gps/algorithm/algorithm_badmm.py
@@ -288,7 +288,7 @@ class AlgorithmBADMM(Algorithm):
         for m in range(self.M):
             self.cur[m].traj_info.last_kl_step = \
                     self.prev[m].traj_info.last_kl_step
-            self.cur[m].pol_info = self.prev[m].pol_info
+            self.cur[m].pol_info = copy.deepcopy(self.prev[m].pol_info)
 
     def _stepadjust(self, m):
         """
@@ -300,19 +300,19 @@ class AlgorithmBADMM(Algorithm):
         # that the previous samples were actually drawn from under the
         # dynamics that were estimated from the previous samples.
         prev_laplace_obj, prev_laplace_kl = self._estimate_cost(
-            self.prev[m].traj_distr, self.prev[m].traj_info, m
+            self.prev[m].traj_distr, self.prev[m].traj_info, self.prev[m].pol_info, m
         )
         # This is the policy that we just used under the dynamics that
         # were estimated from the previous samples (so this is the cost
         # we thought we would have).
         new_pred_laplace_obj, new_pred_laplace_kl = self._estimate_cost(
-            self.cur[m].traj_distr, self.prev[m].traj_info, m
+            self.cur[m].traj_distr, self.prev[m].traj_info, self.prev[m].pol_info, m
         )
 
         # This is the actual cost we have under the current trajectory
         # based on the latest samples.
         new_actual_laplace_obj, new_actual_laplace_kl = self._estimate_cost(
-            self.cur[m].traj_distr, self.cur[m].traj_info, m
+            self.cur[m].traj_distr, self.cur[m].traj_info, self.cur[m].pol_info, m
         )
 
         # Measure the entropy of the current trajectory (for printout).
@@ -440,16 +440,15 @@ class AlgorithmBADMM(Algorithm):
                     0.5 * np.mean(d_pp_d_l)
         return kl_m, kl, kl_lm, kl_l
 
-    def _estimate_cost(self, traj_distr, traj_info, m):
+    def _estimate_cost(self, traj_distr, traj_info, pol_info, m):
         """
         Compute Laplace approximation to expected cost.
         Args:
             traj_distr: A linear Gaussian policy object.
             traj_info: A TrajectoryInfo object.
+	    pol_info: Policy linearization info.
             m: Condition number.
         """
-        pol_info = self.cur[m].pol_info
-
         # Constants.
         T, dU, dX = self.T, self.dU, self.dX
 

--- a/python/gps/algorithm/algorithm_badmm.py
+++ b/python/gps/algorithm/algorithm_badmm.py
@@ -446,7 +446,7 @@ class AlgorithmBADMM(Algorithm):
         Args:
             traj_distr: A linear Gaussian policy object.
             traj_info: A TrajectoryInfo object.
-	    pol_info: Policy linearization info.
+            pol_info: Policy linearization info.
             m: Condition number.
         """
         # Constants.

--- a/python/gps/algorithm/config.py
+++ b/python/gps/algorithm/config.py
@@ -31,7 +31,7 @@ ALG = {
 # AlgorithmBADMM
 ALG_BADMM = {
     'inner_iterations': 4,
-    'policy_dual_rate': 1.0,
+    'policy_dual_rate': 0.1,
     'policy_dual_rate_covar': 0.0,
     'fixed_lg_step': 0,
     'lg_step_schedule': 10.0,
@@ -41,6 +41,6 @@ ALG_BADMM = {
     'max_policy_samples': 20,
     'exp_step_increase': 2.0,
     'exp_step_decrease': 0.5,
-    'exp_step_upper': 0.0,
-    'exp_step_lower': 2.0,
+    'exp_step_upper': 0.5,
+    'exp_step_lower': 1.0,
 }


### PR DESCRIPTION
This PR contains a number of fixes. These fixes make the peg insertion task succeed (at least for me) on all four conditions. The fixes fall into a few categories:
1. Changes to peg task to match the MATLAB reference:
2. changed hole positions (still 0.2 apart, but center in a different place) -- no idea if this makes a difference
3. changed cost function to raise the action cost and change wp
4. Changes to algorithm parameters
5. lowered dual_rate to 0.1 to match matlab reference
6. changed max samples for GMM prior to match matlab reference
7. raised # of SGD iterations (this seems to have made a difference)
8. Changes to default algorithm settings
9. lowered default polwt to 0.1 (1.0 is way too high for a default)
10. changed the polwt lowering/raising heuristic to match matlab reference
11. Deep copy bugfix
12. added deep copy when flipping prev/cur variables for iteration, this appears to make a difference
