### PR TITLE
Fix to box2d example bug (causing NaNs in the policy & policy prior)

### DIFF
--- a/experiments/box2d_badmm_example/hyperparams.py
+++ b/experiments/box2d_badmm_example/hyperparams.py
@@ -142,7 +142,7 @@ config = {
     'iterations': 10,
     'num_samples': 5,
     'verbose_trials': 5,
-    'verbose_policy_trials': 1,
+    'verbose_policy_trials': 0,
     'common': common,
     'agent': agent,
     'gui_on': True,

--- a/python/gps/algorithm/policy_opt/policy_opt_caffe.py
+++ b/python/gps/algorithm/policy_opt/policy_opt_caffe.py
@@ -137,7 +137,10 @@ class PolicyOptCaffe(PolicyOpt):
 
         # Normalize obs, but only compute normalzation at the beginning.
         if itr == 0 and inner_itr == 1:
-            self.policy.scale = np.diag(1.0 / np.std(obs, axis=0))
+            # 1e-3 to avoid infs if some state dimensions don't change
+            # in the first batch
+            self.policy.scale = np.diag(1.0 / np.maximum(np.std(obs, axis=0),
+                                                         1e-3))
             self.policy.bias = -np.mean(obs.dot(self.policy.scale), axis=0)
         obs = obs.dot(self.policy.scale) + self.policy.bias
 
@@ -166,11 +169,6 @@ class PolicyOptCaffe(PolicyOpt):
                 LOGGER.debug('Caffe iteration %d, average loss %f',
                              i, average_loss / 500)
                 average_loss = 0
-
-            # To run a test:
-            # if i % test_interval:
-            #     print 'Iteration', i, 'testing...'
-            #     solver.test_nets[0].forward()
 
         # Keep track of Caffe iterations for loading solver states.
         self.caffe_iter += self._hyperparams['iterations']

--- a/python/gps/algorithm/policy_opt/policy_opt_caffe.py
+++ b/python/gps/algorithm/policy_opt/policy_opt_caffe.py
@@ -137,8 +137,8 @@ class PolicyOptCaffe(PolicyOpt):
 
         # Normalize obs, but only compute normalzation at the beginning.
         if itr == 0 and inner_itr == 1:
-            # 1e-3 to avoid infs if some state dimensions don't change
-            # in the first batch
+            # 1e-3 to avoid infs if some state dimensions don't change in the
+            # first batch of samples
             self.policy.scale = np.diag(1.0 / np.maximum(np.std(obs, axis=0),
                                                          1e-3))
             self.policy.bias = -np.mean(obs.dot(self.policy.scale), axis=0)

--- a/python/gps/algorithm/policy_opt/policy_opt_tf.py
+++ b/python/gps/algorithm/policy_opt/policy_opt_tf.py
@@ -117,7 +117,8 @@ class PolicyOptTf(PolicyOpt):
         # Normalize obs, but only compute normalzation at the beginning.
         if itr == 0 and inner_itr == 1:
             self.policy.x_idx = self.x_idx
-            self.policy.scale = np.diag(1.0 / np.std(obs[:, self.x_idx], axis=0))
+            # 1e-3 to avoid infs if some state dimensions don't change in the
+            # first batch of samples
             self.policy.scale = np.diag(
                 1.0 / np.maximum(np.std(obs[:, self.x_idx], axis=0), 1e-3))
             self.policy.bias = - np.mean(

--- a/python/gps/algorithm/policy_opt/policy_opt_tf.py
+++ b/python/gps/algorithm/policy_opt/policy_opt_tf.py
@@ -118,7 +118,10 @@ class PolicyOptTf(PolicyOpt):
         if itr == 0 and inner_itr == 1:
             self.policy.x_idx = self.x_idx
             self.policy.scale = np.diag(1.0 / np.std(obs[:, self.x_idx], axis=0))
-            self.policy.bias = -np.mean(obs[:, self.x_idx].dot(self.policy.scale), axis=0)
+            self.policy.scale = np.diag(
+                1.0 / np.maximum(np.std(obs[:, self.x_idx], axis=0), 1e-3))
+            self.policy.bias = - np.mean(
+                obs[:, self.x_idx].dot(self.policy.scale), axis=0)
         obs[:, self.x_idx] = obs[:, self.x_idx].dot(self.policy.scale) + self.policy.bias
 
         # Assuming that N*T >= self.batch_size.
@@ -150,7 +153,7 @@ class PolicyOptTf(PolicyOpt):
 
         # Optimize variance.
         A = np.sum(tgt_prc_orig, 0) + 2 * N * T * \
-                                      self._hyperparams['ent_reg'] * np.ones((dU, dU))
+                self._hyperparams['ent_reg'] * np.ones((dU, dU))
         A = A / np.sum(tgt_wt)
 
         # TODO - Use dense covariance?


### PR DESCRIPTION
Fix to the bug mentioned in: https://github.com/cbfinn/gps/issues/24

The bug is caused by one dimension of the state never changing, leading to a standard deviation of 0 when normalizing the policy. The policy now trains without error.

There seems like there may be an issue with running the learned policy, which should be looked into. Fixing https://github.com/cbfinn/gps/issues/24 is a priority though.
