### PR TITLE
Properly display KL divergence in the GUI

### DIFF
--- a/python/gps/algorithm/algorithm_badmm.py
+++ b/python/gps/algorithm/algorithm_badmm.py
@@ -49,6 +49,10 @@ class AlgorithmBADMM(Algorithm):
         self._update_policy_samples()  # Choose samples to use with the policy.
         self._update_step_size()  # KL Divergence step size.
 
+        for m in range(self.M):
+          # save initial kl for debugging / visualization
+          self.cur[m].pol_info.init_kl = self._policy_kl(m)[0]
+
         # Run inner loop to compute new policies.
         for inner_itr in range(self._hyperparams['inner_iterations']):
             #TODO: Could start from init controller.

--- a/python/gps/algorithm/algorithm_utils.py
+++ b/python/gps/algorithm/algorithm_utils.py
@@ -49,6 +49,7 @@ class PolicyInfo(BundleType):
             'pol_S': np.zeros((T, dU, dU)),  # Policy linearization covariance.
             'chol_pol_S': np.zeros((T, dU, dU)),  # Cholesky decomp of covar.
             'prev_kl': None,  # Previous KL divergence.
+            'init_kl': None,  # The initial KL divergence, before the iteration.
             'policy_samples': [],  # List of current policy samples.
             'policy_prior': None,  # Current prior for policy linearization.
         }

--- a/python/gps/gui/gps_training_gui.py
+++ b/python/gps/gui/gps_training_gui.py
@@ -311,8 +311,8 @@ class GPSTrainingGUI(object):
                     axis1=1, axis2=2)))
             itr_data += ' | %8.2f %8.2f %8.2f' % (cost, step, entropy)
             if algorithm.prev[0].pol_info is not None:
-                kl_div_i = algorithm.prev[m].pol_info.prev_kl[0]
-                kl_div_f = algorithm.prev[m].pol_info.prev_kl[-1]
+                kl_div_i = algorithm.cur[m].pol_info.init_kl.sum()
+                kl_div_f = algorithm.cur[m].pol_info.prev_kl.sum()
                 itr_data += ' %8.2f %8.2f' % (kl_div_i, kl_div_f)
         self.append_output_text(itr_data)
 


### PR DESCRIPTION
Fix the KL divergence GUI print out to show the KL divergence summed over time before the iteration and after the iteration.

Will affect the MDGPS pull request (in a fairly minor way)
