### PR TITLE
Fix to very minor mujoco bug

### DIFF
--- a/experiments/mjc_pointmass_example/hyperparams.py
+++ b/experiments/mjc_pointmass_example/hyperparams.py
@@ -16,13 +16,15 @@ from gps.algorithm.traj_opt.traj_opt_lqr_python import TrajOptLQRPython
 from gps.algorithm.policy_opt.policy_opt_caffe import PolicyOptCaffe
 from gps.algorithm.policy.lin_gauss_init import init_lqr
 from gps.algorithm.policy.policy_prior import PolicyPrior
-from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, ACTION
+from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, ACTION
 from gps.gui.config import generate_experiment_info
 
 
 SENSOR_DIMS = {
     JOINT_ANGLES: 2,
     JOINT_VELOCITIES: 2,
+    END_EFFECTOR_POINTS: 3,
+    END_EFFECTOR_POINT_VELOCITIES: 3,
     ACTION: 2,
 }
 
@@ -53,8 +55,8 @@ agent = {
     'conditions': common['conditions'],
     'T': 100,
     'sensor_dims': SENSOR_DIMS,
-    'state_include': [JOINT_ANGLES, JOINT_VELOCITIES],
-    'obs_include': [JOINT_ANGLES, JOINT_VELOCITIES],
+    'state_include': [JOINT_ANGLES, JOINT_VELOCITIES, END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES],
+    'obs_include': [JOINT_ANGLES, JOINT_VELOCITIES, END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES],
 }
 
 algorithm = {

--- a/python/gps/agent/mjc/agent_mjc.py
+++ b/python/gps/agent/mjc/agent_mjc.py
@@ -50,12 +50,10 @@ class AgentMuJoCo(Agent):
         # Initialize Mujoco worlds. If there's only one xml file, create a single world object,
         # otherwise create a different world for each condition.
         if not isinstance(filename, list):
-            self._world = mjcpy.MJCWorld(filename)
-            self._model = self._world.get_model()
-            self._world = [self._world
+            self._world = [mjcpy.MJCWorld(filename)
                            for _ in range(self._hyperparams['conditions'])]
-            self._model = [copy.deepcopy(self._model)
-                           for _ in range(self._hyperparams['conditions'])]
+            self._model = [self._world[i].get_model()
+                           for i in range(self._hyperparams['conditions'])]
         else:
             for i in range(self._hyperparams['conditions']):
                 self._world.append(mjcpy.MJCWorld(self._hyperparams['filename'][i]))


### PR DESCRIPTION
- Fix mujoco agent bug, that incorrectly set the end effector points of the first time step of every sample for all but one of the conditions. (cleanest way to do this would be to omit joint angles and joint velocities from state, and only include ee point data types)
- Add end-effector points to point mass example, for visualization purposes
