### PR TITLE
Include variance in NN policy for ros agent

### DIFF
--- a/python/gps/agent/ros/agent_ros.py
+++ b/python/gps/agent/ros/agent_ros.py
@@ -135,6 +135,7 @@ class AgentROS(Agent):
                        condition_data[TRIAL_ARM]['data'])
         self.reset_arm(AUXILIARY_ARM, condition_data[AUXILIARY_ARM]['mode'],
                        condition_data[AUXILIARY_ARM]['data'])
+        time.sleep(2.0)  # useful for the real robot, so it stops completely
 
     def sample(self, policy, condition, verbose=True, save=True, noisy=True):
         """

--- a/python/gps/agent/ros/ros_utils.py
+++ b/python/gps/agent/ros/ros_utils.py
@@ -56,7 +56,10 @@ def policy_to_msg(policy, noise):
         scale_shape = policy.scale.shape
         msg.caffe.scale = policy.scale.reshape(scale_shape[0] * scale_shape[1]).tolist()
         msg.caffe.dim_bias = scale_shape[0]
-        msg.caffe.noise = policy.chol_pol_covar.T.dot(noise)
+        scaled_noise = np.zeros_like(noise)
+        for i in range(noise.shape[0]):
+            scaled_noise[i] = policy.chol_pol_covar[i].T.dot(noise[i])
+        msg.caffe.noise = scaled_noise.reshape(-1).tolist()
     elif isinstance(policy, TfPolicy):
         msg.controller_to_execute = TF_CONTROLLER
         msg.tf = TfParams()

--- a/python/gps/agent/ros/ros_utils.py
+++ b/python/gps/agent/ros/ros_utils.py
@@ -56,6 +56,7 @@ def policy_to_msg(policy, noise):
         scale_shape = policy.scale.shape
         msg.caffe.scale = policy.scale.reshape(scale_shape[0] * scale_shape[1]).tolist()
         msg.caffe.dim_bias = scale_shape[0]
+        msg.caffe.noise = policy.chol_pol_covar.T.dot(noise)
     elif isinstance(policy, TfPolicy):
         msg.controller_to_execute = TF_CONTROLLER
         msg.tf = TfParams()

--- a/python/gps/agent/ros/ros_utils.py
+++ b/python/gps/agent/ros/ros_utils.py
@@ -53,12 +53,13 @@ def policy_to_msg(policy, noise):
         msg.caffe = CaffeParams()
         msg.caffe.net_param = policy.get_net_param()
         msg.caffe.bias = policy.bias.tolist()
+        msg.caffe.dU = policy.dU
         scale_shape = policy.scale.shape
         msg.caffe.scale = policy.scale.reshape(scale_shape[0] * scale_shape[1]).tolist()
         msg.caffe.dim_bias = scale_shape[0]
         scaled_noise = np.zeros_like(noise)
         for i in range(noise.shape[0]):
-            scaled_noise[i] = policy.chol_pol_covar[i].T.dot(noise[i])
+            scaled_noise[i] = policy.chol_pol_covar.T.dot(noise[i])
         msg.caffe.noise = scaled_noise.reshape(-1).tolist()
     elif isinstance(policy, TfPolicy):
         msg.controller_to_execute = TF_CONTROLLER

--- a/python/gps/algorithm/policy/caffe_policy.py
+++ b/python/gps/algorithm/policy/caffe_policy.py
@@ -20,6 +20,7 @@ class CaffePolicy(Policy):
         self.net = test_net
         self.deploy_net = deploy_net
         self.chol_pol_covar = np.diag(np.sqrt(var))
+        self.dU = var.shape[-1]
         self.scale = None  # must be set from elsewhere based on observations
         self.bias = None
 

--- a/src/gps_agent_pkg/include/gps_agent_pkg/caffenncontroller.h
+++ b/src/gps_agent_pkg/include/gps_agent_pkg/caffenncontroller.h
@@ -20,6 +20,7 @@ class CaffeNNController : public TrialController
 private:
     // Pointer to Caffe network
     boost::scoped_ptr<NeuralNetworkCaffe> net_;
+    Eigen::VectorXd noise_;
 public:
     // Constructor.
     CaffeNNController();

--- a/src/gps_agent_pkg/include/gps_agent_pkg/caffenncontroller.h
+++ b/src/gps_agent_pkg/include/gps_agent_pkg/caffenncontroller.h
@@ -20,7 +20,7 @@ class CaffeNNController : public TrialController
 private:
     // Pointer to Caffe network
     boost::scoped_ptr<NeuralNetworkCaffe> net_;
-    Eigen::VectorXd noise_;
+    std::vector<Eigen::VectorXd> noise_;
 public:
     // Constructor.
     CaffeNNController();

--- a/src/gps_agent_pkg/msg/CaffeParams.msg
+++ b/src/gps_agent_pkg/msg/CaffeParams.msg
@@ -1,4 +1,5 @@
 string net_param # Serialized net parameter with weights (equivalent of prototxt file)
 float32[] bias
 float32[] scale
+float32[] noise
 int32 dim_bias

--- a/src/gps_agent_pkg/msg/CaffeParams.msg
+++ b/src/gps_agent_pkg/msg/CaffeParams.msg
@@ -3,3 +3,4 @@ float32[] bias
 float32[] scale
 float32[] noise
 int32 dim_bias
+uint32 dU

--- a/src/gps_agent_pkg/src/caffenncontroller.cpp
+++ b/src/gps_agent_pkg/src/caffenncontroller.cpp
@@ -20,7 +20,7 @@ CaffeNNController::~CaffeNNController()
 
 void CaffeNNController::get_action(int t, const Eigen::VectorXd &X, const Eigen::VectorXd &obs, Eigen::VectorXd &U){
     if (is_configured_) {
-        net_->forward(obs, U);
+        net_->forward(obs, U) + noise_;
     }
 }
 
@@ -41,6 +41,8 @@ void CaffeNNController::configure_controller(OptionsMap &options)
     Eigen::MatrixXd scale = boost::get<Eigen::MatrixXd>(options["scale"]);
     Eigen::VectorXd bias  = boost::get<Eigen::VectorXd>(options["bias"]);
     net_->set_scalebias(scale, bias);
+
+    noise_ = boost::get<Eigen::VectorXd>(options["noise"]);
 
     ROS_INFO_STREAM("Set Caffe network parameters");
     is_configured_ = true;

--- a/src/gps_agent_pkg/src/caffenncontroller.cpp
+++ b/src/gps_agent_pkg/src/caffenncontroller.cpp
@@ -20,7 +20,8 @@ CaffeNNController::~CaffeNNController()
 
 void CaffeNNController::get_action(int t, const Eigen::VectorXd &X, const Eigen::VectorXd &obs, Eigen::VectorXd &U){
     if (is_configured_) {
-        net_->forward(obs, U) + noise_;
+        net_->forward(obs, U);
+        U = U + noise_[t];
     }
 }
 
@@ -42,7 +43,11 @@ void CaffeNNController::configure_controller(OptionsMap &options)
     Eigen::VectorXd bias  = boost::get<Eigen::VectorXd>(options["bias"]);
     net_->set_scalebias(scale, bias);
 
-    noise_ = boost::get<Eigen::VectorXd>(options["noise"]);
+    int T = boost::get<int>(options["T"]);
+    noise_.resize(T);
+    for(int i=0; i<T; i++){
+        noise_[i] = boost::get<Eigen::VectorXd>(options["noise_"+to_string(i)]);
+    }
 
     ROS_INFO_STREAM("Set Caffe network parameters");
     is_configured_ = true;

--- a/src/gps_agent_pkg/src/lingausscontroller.cpp
+++ b/src/gps_agent_pkg/src/lingausscontroller.cpp
@@ -18,6 +18,7 @@ LinearGaussianController::~LinearGaussianController()
 
 
 void LinearGaussianController::get_action(int t, const Eigen::VectorXd &X, const Eigen::VectorXd &obs, Eigen::VectorXd &U){
+    // Noise usually contained in k_
     U = K_[t]*X+k_[t];
 }
 

--- a/src/gps_agent_pkg/src/neuralnetworkcaffe.cpp
+++ b/src/gps_agent_pkg/src/neuralnetworkcaffe.cpp
@@ -37,7 +37,7 @@ void NeuralNetworkCaffe::forward(const Eigen::VectorXd &input, std::vector<float
 {
     // Transform the input by scale and bias.
     // Note that this assumes that all state information that we don't want to feed to the network is stored at the end of the state vector.
-    assert(x.rows() >= input_scaled_.rows());
+    assert(input.rows() >= input_scaled_.rows());
     input_scaled_ = scale_*input.segment(0, input_scaled_.rows()) + bias_;
 
     ROS_FATAL("Forward with >1 input not implemented!");
@@ -49,7 +49,7 @@ void NeuralNetworkCaffe::forward(const Eigen::VectorXd &input, Eigen::VectorXd &
 {
     // Transform the input by scale and bias.
     // Note that this assumes that all state information that we don't want to feed to the network is stored at the end of the state vector.
-    assert(x.rows() >= input_scaled_.rows());
+    assert(input.rows() >= input_scaled_.rows());
     input_scaled_ = scale_ * input.segment(0, input_scaled_.rows()) + bias_;
 
     Blob<float>* input_blob = net_->bottom_vecs()[1][0];

--- a/src/gps_agent_pkg/src/robotplugin.cpp
+++ b/src/gps_agent_pkg/src/robotplugin.cpp
@@ -399,6 +399,8 @@ void RobotPlugin::trial_subscriber_callback(const gps_agent_pkg::TrialCommand::C
         Eigen::VectorXd bias;
         bias.resize(dim_bias);
 
+        int dU = (int) params.dU;
+
         int idx = 0;
         // Unpack the scale matrix
         for (int j = 0; j < dim_bias; ++j)

--- a/src/gps_agent_pkg/src/robotplugin.cpp
+++ b/src/gps_agent_pkg/src/robotplugin.cpp
@@ -418,6 +418,15 @@ void RobotPlugin::trial_subscriber_callback(const gps_agent_pkg::TrialCommand::C
             idx++;
         }
 
+        for(int t=0; t<(int)msg->T; t++){
+            Eigen::VectorXd noise;
+            noise.resize(dU);
+            for(int u=0; u<dU; u++){
+                noise(u) = params.noise[u+t*dU];
+            }
+            controller_params["noise_"+to_string(t)] = noise;
+        }
+ 
         controller_params["net_param"] = params.net_param;
         controller_params["scale"] = scale;
         controller_params["bias"] = bias;


### PR DESCRIPTION
This PR adds functionality to run neural net policies with non-zero variance on the PR2/agent_ros. This is **crucial** for running MDGPS with agent_ros.

This PR also adds a 2 second wait after the agent_ros reset, which is important for running experiments on the real robot, but not necessary for gazebo experiments (and will slow down gazebo experiments).

Lastly, it includes a minor bug fix in neuralnetworkcaffe.cpp.
