### PR TITLE
Caffe to TF Hyper parameter option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -212,7 +212,7 @@ python python/gps/gps_main.py mjc_badmm_example
 The robot learns a neural network policy for inserting the peg under varying initial conditions.
 
 To tinker with the hyperparameters and input, take a look at `experiments/mjc_badmm_example/hyperparams.py`.
-Additionally, the neural network library can be changed through the `ALGORITHM_BACKEND` variable which can be set to `caffe` or `tf`.
+Additionally, the neural network library can be changed through the `ALGORITHM_NN_LIBRARY` variable which can be set to `caffe` or `tf`.
 
 #### PR2 example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -212,6 +212,7 @@ python python/gps/gps_main.py mjc_badmm_example
 The robot learns a neural network policy for inserting the peg under varying initial conditions.
 
 To tinker with the hyperparameters and input, take a look at `experiments/mjc_badmm_example/hyperparams.py`.
+Additionally, the neural network library can be changed through the `ALGORITHM_BACKEND` variable which can be set to `caffe` or `tf`.
 
 #### PR2 example
 

--- a/experiments/mjc_badmm_example/hyperparams.py
+++ b/experiments/mjc_badmm_example/hyperparams.py
@@ -20,10 +20,13 @@ from gps.algorithm.policy_opt.policy_opt_caffe import PolicyOptCaffe
 from gps.algorithm.policy.lin_gauss_init import init_lqr
 from gps.algorithm.policy.policy_prior_gmm import PolicyPriorGMM
 from gps.algorithm.policy.policy_prior import PolicyPrior
+from gps.algorithm.policy_opt.policy_opt_tf import PolicyOptTf
+from gps.algorithm.policy_opt.tf_model_example import example_tf_network
 from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, \
         END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, ACTION
 from gps.gui.config import generate_experiment_info
 
+ALGORITHM_BACKEND = "caffe"
 
 SENSOR_DIMS = {
     JOINT_ANGLES: 7,
@@ -147,12 +150,23 @@ algorithm['dynamics'] = {
 algorithm['traj_opt'] = {
     'type': TrajOptLQRPython,
 }
-
-algorithm['policy_opt'] = {
+if ALGORITHM_BACKEND == "tf":
+    algorithm['policy_opt'] = {
+        'type': PolicyOptTf,
+        'network_params': {
+            'obs_include': [JOINT_ANGLES, JOINT_VELOCITIES, END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES],
+            'sensor_dims': SENSOR_DIMS,
+        },
+        'weights_file_prefix': EXP_DIR + 'policy',
+        'iterations': 3000,
+        'network_model': example_tf_network
+    }
+elif ALGORITHM_BACKEND = "caffe":
+    algorithm['policy_opt'] = {
     'type': PolicyOptCaffe,
     'weights_file_prefix': EXP_DIR + 'policy',
     'iterations': 5000,
-}
+    }
 
 algorithm['policy_prior'] = {
     'type': PolicyPriorGMM,

--- a/experiments/mjc_badmm_example/hyperparams.py
+++ b/experiments/mjc_badmm_example/hyperparams.py
@@ -26,7 +26,7 @@ from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, \
         END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, ACTION
 from gps.gui.config import generate_experiment_info
 
-ALGORITHM_BACKEND = "caffe"
+ALGORITHM_NN_LIBRARY = "caffe"
 
 SENSOR_DIMS = {
     JOINT_ANGLES: 7,
@@ -150,7 +150,7 @@ algorithm['dynamics'] = {
 algorithm['traj_opt'] = {
     'type': TrajOptLQRPython,
 }
-if ALGORITHM_BACKEND == "tf":
+if ALGORITHM_NN_LIBRARY == "tf":
     algorithm['policy_opt'] = {
         'type': PolicyOptTf,
         'network_params': {
@@ -161,7 +161,7 @@ if ALGORITHM_BACKEND == "tf":
         'iterations': 3000,
         'network_model': example_tf_network
     }
-elif ALGORITHM_BACKEND = "caffe":
+elif ALGORITHM_NN_LIBRARY = "caffe":
     algorithm['policy_opt'] = {
     'type': PolicyOptCaffe,
     'weights_file_prefix': EXP_DIR + 'policy',


### PR DESCRIPTION
I had difficulties getting Caffe to work with the generalization MuJoCo example. I found a pull request from @wmontgomery4 to switch to TensorFlow in the hyperparams file and so I added an easy way to switch between libraries by adding another parameter. 
I've also added a line to the MJC examples documentation to make it clear how to access this.
