### PR TITLE
Fix memory leak

### DIFF
--- a/experiments/mjc_mdgps_example/hyperparams.py
+++ b/experiments/mjc_mdgps_example/hyperparams.py
@@ -41,8 +41,15 @@ EXP_DIR = BASE_DIR + '/../experiments/mjc_mdgps_example/'
 common = {
     'experiment_name': 'my_experiment' + '_' + \
             datetime.strftime(datetime.now(), '%m-%d-%y_%H-%M'),
+    'experiment_dir': EXP_DIR,
+    'data_files_dir': EXP_DIR + 'data_files/',
+    'target_filename': EXP_DIR + 'target.npz',
+    'log_filename': EXP_DIR + 'log.txt',
     'conditions': 4,
 }
+
+if not os.path.exists(common['data_files_dir']):
+    os.makedirs(common['data_files_dir'])
 
 agent = {
     'type': AgentMuJoCo,
@@ -147,10 +154,14 @@ algorithm['policy_prior'] = {
 }
 
 config = {
+    'gui_on': True,
     'iterations': algorithm['iterations'],
     'num_samples': 5,
     'verbose_trials': 1,
     'verbose_policy_trials': 1,
+    'common': common,
     'agent': agent,
-    'gui_on': True,
+    'algorithm': algorithm,
 }
+
+common['info'] = generate_experiment_info(config)

--- a/python/gps/agent/agent.py
+++ b/python/gps/agent/agent.py
@@ -84,6 +84,17 @@ class Agent(object):
         return (SampleList(self._samples[condition][start:]) if end is None
                 else SampleList(self._samples[condition][start:end]))
 
+    def clear_samples(self, condition=None):
+        """
+        Reset the samples for a given condition, defaulting to all conditions.
+        Args:
+            condition: Condition for which to reset samples.
+        """
+        if condition is None:
+            self._samples = [[] for _ in range(self._hyperparams['conditions'])]
+        else:
+            self._samples[condition] = []
+
     def delete_last_sample(self, condition):
         """ Delete the last sample from the specified condition. """
         self._samples[condition].pop()

--- a/python/gps/agent/box2d/agent_box2d.py
+++ b/python/gps/agent/box2d/agent_box2d.py
@@ -76,6 +76,7 @@ class AgentBox2D(Agent):
         new_sample.set(ACTION, U)
         if save:
             self._samples[condition].append(new_sample)
+        return new_sample
 
     def _init_sample(self, b2d_X):
         """

--- a/python/gps/algorithm/algorithm_mdgps.py
+++ b/python/gps/algorithm/algorithm_mdgps.py
@@ -147,9 +147,9 @@ class AlgorithmMDGPS(Algorithm):
         """
         # Compute previous cost and previous expected cost.
         prev_M = len(self.prev) # May be different in future.
-        prev_laplace = np.arange(prev_M)
-        prev_mc = np.arange(prev_M)
-        prev_predicted = np.arange(prev_M)
+        prev_laplace = np.empty(prev_M)
+        prev_mc = np.empty(prev_M)
+        prev_predicted = np.empty(prev_M)
         for m in range(prev_M):
             prev_nn = self.prev[m].pol_info.traj_distr()
             prev_lg = self.prev[m].new_traj_distr
@@ -170,8 +170,8 @@ class AlgorithmMDGPS(Algorithm):
             ).sum()
 
         # Compute current cost.
-        cur_laplace = np.arange(self.M)
-        cur_mc = np.arange(self.M)
+        cur_laplace = np.empty(self.M)
+        cur_mc = np.empty(self.M)
         for m in range(self.M):
             cur_nn = self.cur[m].pol_info.traj_distr()
             # This is the actual cost we have under the current trajectory

--- a/python/gps/gps_main.py
+++ b/python/gps/gps_main.py
@@ -69,6 +69,10 @@ class GPSMain(object):
                 self.agent.get_samples(cond, -self._hyperparams['num_samples'])
                 for cond in self._train_idx
             ]
+
+            # Clear agent samples.
+            self.agent.clear_samples()
+
             self._take_iteration(itr, traj_sample_lists)
             pol_sample_lists = self._take_policy_samples()
             self._log_data(itr, traj_sample_lists, pol_sample_lists)


### PR DESCRIPTION
This includes the following
- Fix memory "leak" by removing old samples from agent. Pretty sure this is okay to do since we never need the ones from previous iterations
- Fix `sample` method for `agent_box2d`
- Fix `stepadjust` method in `algorithm_mdgps` (was using `arange` instead of `empty`, leading to integer arrays)
- Fix `mjc_mdgps_example` (I broke this on a previous commit when changing the `stepadjust` method, sorry!)
