### PR TITLE
PILQR

### DIFF
--- a/experiments/box2d_pointmass_pi2_example/hyperparams.py
+++ b/experiments/box2d_pointmass_pi2_example/hyperparams.py
@@ -8,14 +8,14 @@ import numpy as np
 from gps import __file__ as gps_filepath
 from gps.agent.box2d.agent_box2d import AgentBox2D
 from gps.agent.box2d.point_mass_world import PointMassWorld
-from gps.algorithm.algorithm_traj_opt_pi2 import AlgorithmTrajOptPi2
+from gps.algorithm.algorithm_traj_opt_pi2 import AlgorithmTrajOptPI2
 from gps.algorithm.cost.cost_state import CostState
 from gps.algorithm.cost.cost_action import CostAction
 from gps.algorithm.cost.cost_sum import CostSum
 from gps.algorithm.cost.cost_utils import RAMP_LINEAR, RAMP_QUADRATIC
 from gps.algorithm.dynamics.dynamics_lr_prior import DynamicsLRPrior
 from gps.algorithm.dynamics.dynamics_prior_gmm import DynamicsPriorGMM
-from gps.algorithm.traj_opt.traj_opt_pi2 import TrajOptPi2
+from gps.algorithm.traj_opt.traj_opt_pi2 import TrajOptPI2
 from gps.algorithm.policy.lin_gauss_init import init_pd
 from gps.proto.gps_pb2 import END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, ACTION
 from gps.gui.config import generate_experiment_info
@@ -64,7 +64,7 @@ agent = {
 }
 
 algorithm = {
-    'type': AlgorithmTrajOptPi2,
+    'type': AlgorithmTrajOptPI2,
     'conditions': common['conditions'],
 }
 
@@ -99,7 +99,7 @@ algorithm['cost'] = {
 }
 
 algorithm['traj_opt'] = {
-    'type': TrajOptPi2,
+    'type': TrajOptPI2,
     'kl_threshold': 2.0,
     'covariance_damping': 2.0,
     'min_temperature': 0.001,

--- a/experiments/box2d_pointmass_pigps_example/hyperparams.py
+++ b/experiments/box2d_pointmass_pigps_example/hyperparams.py
@@ -16,7 +16,7 @@ from gps.algorithm.cost.cost_sum import CostSum
 from gps.algorithm.dynamics.dynamics_lr_prior import DynamicsLRPrior
 from gps.algorithm.dynamics.dynamics_prior_gmm import DynamicsPriorGMM
 from gps.algorithm.policy_opt.policy_opt_caffe import PolicyOptCaffe
-from gps.algorithm.traj_opt.traj_opt_pi2 import TrajOptPi2
+from gps.algorithm.traj_opt.traj_opt_pi2 import TrajOptPI2
 from gps.algorithm.policy.policy_prior import PolicyPrior
 from gps.algorithm.policy.lin_gauss_init import init_pd
 from gps.proto.gps_pb2 import END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, ACTION
@@ -106,7 +106,7 @@ algorithm['cost'] = {
 }
 
 algorithm['traj_opt'] = {
-    'type': TrajOptPi2,
+    'type': TrajOptPI2,
     'kl_threshold': 2.0,
     'covariance_damping': 2.0,
     'min_temperature': 0.001,

--- a/experiments/mjc_badmm_example/hyperparams.py
+++ b/experiments/mjc_badmm_example/hyperparams.py
@@ -21,7 +21,7 @@ from gps.algorithm.policy.lin_gauss_init import init_lqr
 from gps.algorithm.policy.policy_prior_gmm import PolicyPriorGMM
 from gps.algorithm.policy.policy_prior import PolicyPrior
 from gps.algorithm.policy_opt.policy_opt_tf import PolicyOptTf
-from gps.algorithm.policy_opt.tf_model_example import example_tf_network
+from gps.algorithm.policy_opt.tf_model_example import tf_network
 from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, \
         END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, ACTION
 from gps.gui.config import generate_experiment_info
@@ -160,7 +160,7 @@ if ALGORITHM_NN_LIBRARY == "tf":
         },
         'weights_file_prefix': EXP_DIR + 'policy',
         'iterations': 3000,
-        'network_model': example_tf_network
+        'network_model': tf_network
     }
 elif ALGORITHM_NN_LIBRARY == "caffe":
     algorithm['policy_opt'] = {

--- a/experiments/mjc_disc_cost_example/hyperparams.py
+++ b/experiments/mjc_disc_cost_example/hyperparams.py
@@ -1,0 +1,139 @@
+""" Hyperparameters for MJC 2D navigation with discontinous target region. """
+from __future__ import division
+
+from datetime import datetime
+import os.path
+
+import numpy as np
+
+from gps import __file__ as gps_filepath
+from gps.agent.mjc.agent_mjc import AgentMuJoCo
+from gps.algorithm.algorithm_traj_opt_pilqr import AlgorithmTrajOptPILQR
+from gps.algorithm.cost.cost_state import CostState
+from gps.algorithm.cost.cost_binary_region import CostBinaryRegion
+from gps.algorithm.cost.cost_sum import CostSum
+from gps.algorithm.dynamics.dynamics_lr_prior import DynamicsLRPrior
+from gps.algorithm.dynamics.dynamics_prior_gmm import DynamicsPriorGMM
+from gps.algorithm.traj_opt.traj_opt_pilqr import TrajOptPILQR
+from gps.algorithm.policy.lin_gauss_init import init_lqr
+from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, \
+        END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, ACTION
+from gps.gui.config import generate_experiment_info
+
+
+SENSOR_DIMS = {
+    JOINT_ANGLES: 2,
+    JOINT_VELOCITIES: 2,
+    END_EFFECTOR_POINTS: 3,
+    END_EFFECTOR_POINT_VELOCITIES: 3,
+    ACTION: 2,
+}
+
+BASE_DIR = '/'.join(str.split(gps_filepath, '/')[:-2])
+EXP_DIR = BASE_DIR + '/../experiments/mjc_disc_cost_example/'
+
+
+common = {
+    'experiment_name': 'my_experiment' + '_' + \
+            datetime.strftime(datetime.now(), '%m-%d-%y_%H-%M'),
+    'experiment_dir': EXP_DIR,
+    'data_files_dir': EXP_DIR + 'data_files/',
+    'target_filename': EXP_DIR + 'target.npz',
+    'log_filename': EXP_DIR + 'log.txt',
+    'conditions': 1,
+}
+
+if not os.path.exists(common['data_files_dir']):
+    os.makedirs(common['data_files_dir'])
+
+agent = {
+    'type': AgentMuJoCo,
+    'filename': './mjc_models/pointmass_disc_cost.xml',
+    'x0': [np.array([1., 0., 0., 0.])],
+    'dt': 0.05,
+    'substeps': 5,
+    'conditions': common['conditions'],
+    'T': 100,
+    'sensor_dims': SENSOR_DIMS,
+    'state_include': [JOINT_ANGLES, JOINT_VELOCITIES,
+                      END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES],
+    'obs_include': [JOINT_ANGLES, JOINT_VELOCITIES,
+                    END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES],
+    'camera_pos': np.array([5., 6., 6.5, 0., 0., 0.]),
+    'smooth_noise_var': 3.,
+}
+
+algorithm = {
+    'type': AlgorithmTrajOptPILQR,
+    'conditions': common['conditions'],
+    'iterations': 20,
+    'step_rule': 'res_percent',
+    'step_rule_res_ratio_inc': 0.05,
+    'step_rule_res_ratio_dec': 0.2,
+}
+
+algorithm['init_traj_distr'] = {
+    'type': init_lqr,
+    'init_var': 20.,
+    'dt': agent['dt'],
+    'T': agent['T'],
+}
+
+state_cost = {
+    'type': CostState,
+    'data_types' : {
+        END_EFFECTOR_POINTS: {
+            'wp': np.ones(SENSOR_DIMS[END_EFFECTOR_POINTS]),
+            'target_state': np.array([3., 0, 0]),
+        },
+    },
+}
+
+binary_region_cost = {
+    'type': CostBinaryRegion,
+    'data_types' : {
+        END_EFFECTOR_POINTS: {
+            'wp': np.ones(SENSOR_DIMS[END_EFFECTOR_POINTS]),
+            'target_state': np.array([2.5, 0.5, 0]),
+            'max_distance': 0.3,
+            'outside_cost': 0.,
+            'inside_cost': -3.,
+        },
+    },
+}
+
+algorithm['cost'] = {
+    'type': CostSum,
+    'costs': [state_cost, binary_region_cost],
+    'weights': [1., 10.],
+}
+
+algorithm['dynamics'] = {
+    'type': DynamicsLRPrior,
+    'regularization': 1e-6,
+    'prior': {
+        'type': DynamicsPriorGMM,
+        'max_clusters': 2,
+        'min_samples_per_cluster': 40,
+        'max_samples': 20,
+    }
+}
+
+algorithm['traj_opt'] = {
+    'type': TrajOptPILQR,
+    'kl_threshold': 1.0,
+}
+
+algorithm['policy_opt'] = {}
+
+config = {
+    'iterations': algorithm['iterations'],
+    'num_samples': 20,
+    'verbose_trials': 1,
+    'common': common,
+    'agent': agent,
+    'gui_on': True,
+    'algorithm': algorithm,
+}
+
+common['info'] = generate_experiment_info(config)

--- a/experiments/mjc_door_opening/hyperparams.py
+++ b/experiments/mjc_door_opening/hyperparams.py
@@ -1,0 +1,186 @@
+""" Hyperparameters for MJC door opening trajectory optimization. """
+from __future__ import division
+
+from datetime import datetime
+import os.path
+import numpy as np
+
+from gps import __file__ as gps_filepath
+from gps.agent.mjc.agent_mjc import AgentMuJoCo
+from gps.algorithm.algorithm_mdgps_pilqr import AlgorithmMDGPSPILQR
+from gps.algorithm.cost.cost_state import CostState
+from gps.algorithm.cost.cost_lin_wp import CostLinWP
+from gps.algorithm.cost.cost_action import CostAction
+from gps.algorithm.cost.cost_sum import CostSum
+from gps.algorithm.cost.cost_utils import RAMP_QUADRATIC
+from gps.algorithm.dynamics.dynamics_lr_prior import DynamicsLRPrior
+from gps.algorithm.dynamics.dynamics_prior_gmm import DynamicsPriorGMM
+from gps.algorithm.policy_opt.policy_opt_tf import PolicyOptTf
+from gps.algorithm.policy.policy_prior_gmm import PolicyPriorGMM
+from gps.algorithm.traj_opt.traj_opt_pilqr import TrajOptPILQR
+from gps.algorithm.policy.lin_gauss_init import init_lqr
+from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, \
+        END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, ACTION
+from gps.gui.config import generate_experiment_info
+from gps.algorithm.policy_opt.tf_model_example import tf_network
+
+
+SENSOR_DIMS = {
+    JOINT_ANGLES: 7,
+    JOINT_VELOCITIES: 7,
+    END_EFFECTOR_POINTS: 12,
+    END_EFFECTOR_POINT_VELOCITIES: 12,
+    ACTION: 6,
+}
+
+PR2_GAINS = np.array([3.09, 1.08, 0.393, 0.674, 0.152, 0.098])
+
+BASE_DIR = '/'.join(str.split(gps_filepath, '/')[:-2])
+EXP_DIR = BASE_DIR + '/../experiments/mjc_door_opening/'
+
+
+common = {
+    'experiment_name': 'my_experiment' + '_' + \
+            datetime.strftime(datetime.now(), '%m-%d-%y_%H-%M'),
+    'experiment_dir': EXP_DIR,
+    'data_files_dir': EXP_DIR + 'data_files/',
+    'target_filename': EXP_DIR + 'target.npz',
+    'log_filename': EXP_DIR + 'log.txt',
+    'conditions': 4,
+}
+
+if not os.path.exists(common['data_files_dir']):
+    os.makedirs(common['data_files_dir'])
+
+agent = {
+    'type': AgentMuJoCo,
+    'filename': './mjc_models/pr2_arm3d_door.xml',
+    'x0': np.concatenate([np.array([0.0, 0.5, 0.0, -0.6, -0.2, 0.0, 0.0]),
+                          np.zeros(7)]),
+    'dt': 0.05,
+    'substeps': 5,
+    'conditions': common['conditions'],
+    'pos_body_idx': np.array([1]),
+    'pos_body_offset': [[np.array([0.0, 0.0, 0])], [np.array([0.0, 0.1, 0])],
+                        [np.array([0.1, 0.0, 0])], [np.array([0.1, 0.1, 0])],],
+    'T': 100,
+    'sensor_dims': SENSOR_DIMS,
+    'state_include': [JOINT_ANGLES, JOINT_VELOCITIES,
+                      END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES],
+    'obs_include': [JOINT_ANGLES, JOINT_VELOCITIES,
+                    END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES],
+    'camera_pos': np.array([4.0, 0.0, 1.5, 0., 0., 0.25]),
+    'smooth_noise': False,
+}
+
+algorithm = {
+    'type': AlgorithmMDGPSPILQR,
+    'step_rule': 'const',
+    'conditions': common['conditions'],
+    'iterations': 20,
+    'policy_sample_mode': 'replace',
+    'sample_on_policy': True,
+}
+
+algorithm['init_traj_distr'] = {
+    'type': init_lqr,
+    'init_gains':  1.0 / PR2_GAINS,
+    'init_acc': np.zeros(SENSOR_DIMS[ACTION]),
+    'init_var': 10.0,
+    'stiffness': 1.0,
+    'stiffness_vel': 0.5,
+    'dt': agent['dt'],
+    'T': agent['T'],
+}
+
+torque_cost = {
+    'type': CostAction,
+    'wu': 5e-5 / PR2_GAINS,
+}
+
+state_cost = {
+    'type': CostState,
+    'data_types': {
+        JOINT_ANGLES: {
+            'wp': np.array([0, 0, 0, 0, 0, 0, 1]),
+            'target_state': np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0]),
+        },
+    },
+    'ramp_option': RAMP_QUADRATIC,
+}
+
+_A = np.zeros((2, 44, 44))
+for i in xrange(3):
+    _A[0, i, 17+i] = 1.0
+    _A[0, i, 20+i] = -1.0
+for i in xrange(6):
+    _A[1, i, 14+i] = 1.0
+    _A[1, i, 20+i] = -1.0
+
+linwp_cost = {
+    'type': CostLinWP,
+    'waypoint_time': np.array([0.25, 1.0]),
+    'A': _A,
+    'b': np.array([[0.0] * 44] * 2),
+    'l1': 0.1,
+    'l2': 1.0,
+    'alpha': 1e-5,
+}
+
+algorithm['cost'] = {
+    'type': CostSum,
+    'costs': [torque_cost, state_cost, linwp_cost],
+    'weights': [0.1, 5.0, 1.0],
+}
+
+algorithm['dynamics'] = {
+    'type': DynamicsLRPrior,
+    'regularization': 1e-6,
+    'prior': {
+        'type': DynamicsPriorGMM,
+        'max_clusters': 20,
+        'min_samples_per_cluster': 40,
+        'max_samples': 20,
+    },
+}
+
+algorithm['traj_opt'] = {
+    'type': TrajOptPILQR,
+    'covariance_damping': 10.0,
+    'kl_threshold': 0.5,
+}
+
+algorithm['policy_opt'] = {
+    'type': PolicyOptTf,
+    'network_params': {
+        'obs_include': [JOINT_ANGLES, JOINT_VELOCITIES],
+        'obs_vector_data': [JOINT_ANGLES, JOINT_VELOCITIES],
+        'sensor_dims': SENSOR_DIMS,
+        'n_layers': 2,
+        'dim_hidden': [100, 100],
+    },
+    'network_model': tf_network,
+    'iterations': 4000,
+    'weights_file_prefix': EXP_DIR + 'policy',
+}
+
+algorithm['policy_prior'] = {
+    'type': PolicyPriorGMM,
+    'max_clusters': 20,
+    'min_samples_per_cluster': 40,
+    'max_samples': 20,
+}
+
+config = {
+    'iterations': algorithm['iterations'],
+    'num_samples': 20,
+    'verbose_trials': 1,
+    'verbose_policy_trials': 1,
+    'common': common,
+    'agent': agent,
+    'gui_on': True,
+    'algorithm': algorithm,
+    'random_seed': 1,
+}
+
+common['info'] = generate_experiment_info(config)

--- a/experiments/mjc_gripper_pusher/hyperparams.py
+++ b/experiments/mjc_gripper_pusher/hyperparams.py
@@ -1,0 +1,174 @@
+""" Hyperparameters for MJC gripper pusher task with trajectory optimization."""
+from __future__ import division
+
+from datetime import datetime
+import os.path
+import numpy as np
+
+from gps import __file__ as gps_filepath
+from gps.agent.mjc.agent_mjc import AgentMuJoCo
+from gps.algorithm.algorithm_traj_opt_pilqr import AlgorithmTrajOptPILQR
+from gps.algorithm.cost.cost_fk import CostFK
+from gps.algorithm.cost.cost_state import CostState
+from gps.algorithm.cost.cost_fk_blocktouch import CostFKBlock
+from gps.algorithm.cost.cost_action import CostAction
+from gps.algorithm.cost.cost_sum import CostSum
+from gps.algorithm.dynamics.dynamics_lr_prior import DynamicsLRPrior
+from gps.algorithm.dynamics.dynamics_prior_gmm import DynamicsPriorGMM
+from gps.algorithm.traj_opt.traj_opt_pilqr import TrajOptPILQR
+from gps.algorithm.policy.lin_gauss_init import init_lqr
+from gps.algorithm.cost.cost_utils import RAMP_QUADRATIC
+from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, \
+        END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, ACTION
+from gps.gui.config import generate_experiment_info
+
+
+SENSOR_DIMS = {
+    JOINT_ANGLES: 6,
+    JOINT_VELOCITIES: 6,
+    END_EFFECTOR_POINTS: 12,
+    END_EFFECTOR_POINT_VELOCITIES: 12,
+    ACTION: 4,
+}
+
+GP_GAINS = np.array([1.0, 1.0, 1.0, 1.0])
+
+BASE_DIR = '/'.join(str.split(gps_filepath, '/')[:-2])
+EXP_DIR = BASE_DIR + '/../experiments/mjc_gripper_pusher/'
+
+
+common = {
+    'experiment_name': 'my_experiment' + '_' + \
+            datetime.strftime(datetime.now(), '%m-%d-%y_%H-%M'),
+    'experiment_dir': EXP_DIR,
+    'data_files_dir': EXP_DIR + 'data_files/',
+    'target_filename': EXP_DIR + 'target.npz',
+    'log_filename': EXP_DIR + 'log.txt',
+    'conditions': 4,
+}
+
+if not os.path.exists(common['data_files_dir']):
+    os.makedirs(common['data_files_dir'])
+
+agent = {
+    'type': AgentMuJoCo,
+    'filename': './mjc_models/3link_gripper_pusher.xml',
+    'x0': np.concatenate([np.array([0., 0., 0., 0., 0., 0.]), np.zeros(6)]),
+    'dt': 0.05,
+    'substeps': 5,
+    'conditions': common['conditions'],
+    'pos_body_idx':np.array([6, 8]),
+    'pos_body_offset': [
+        [np.array([0.65, 0.0, -0.9]), np.array([1.6, 0.0, -0.25])],
+        [np.array([1., 0.0, 0.45]), np.array([0.2, 0.0, 1.0])],
+        [np.array([0.9, 0.0, 0.9]), np.array([1.25, 0.0, 0.4])],
+        [np.array([0.5, 0.0, 0.9]), np.array([-0.4, 0.0, 0.75])],
+    ],
+    'T': 100,
+    'sensor_dims': SENSOR_DIMS,
+    'state_include': [JOINT_ANGLES, JOINT_VELOCITIES, END_EFFECTOR_POINTS,
+                      END_EFFECTOR_POINT_VELOCITIES],
+    'obs_include': [],
+    'camera_pos': np.array([0.0, 5.0, 0.0, 0.3, 0.0, 0.3]),
+    'smooth_noise': False,
+}
+
+algorithm = {
+    'type': AlgorithmTrajOptPILQR,
+    'conditions': common['conditions'],
+    'iterations': 20,
+    'step_rule': 'res_percent',
+    'step_rule_res_ratio_dec': 0.2,
+    'step_rule_res_ratio_inc': 0.05,
+    'kl_step': np.linspace(0.6, 0.2, 100),
+}
+
+algorithm['init_traj_distr'] = {
+    'type': init_lqr,
+    'init_gains':  1.0 / GP_GAINS,
+    'init_acc': np.zeros(SENSOR_DIMS[ACTION]),
+    'init_var': 10.0,
+    'stiffness': 1.0,
+    'stiffness_vel': 0.5,
+    'dt': agent['dt'],
+    'T': agent['T'],
+}
+
+torque_cost = {
+    'type': CostAction,
+    'wu': 5e-5 / GP_GAINS,
+}
+
+fk_cost = [{
+    'type': CostFK,
+    'target_end_effector': np.concatenate([np.zeros(6),
+                                           np.array([0.05, 0.05, 0.05]) + agent['pos_body_offset'][i][1],
+                                           np.zeros(3)]),
+    'wp': np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0]),
+    'l1': 0.1,
+    'l2': 10.0,
+    'alpha': 1e-5,
+    'ramp_option': RAMP_QUADRATIC,
+} for i in xrange(common['conditions'])]
+
+cost_tgt = np.zeros(6)
+cost_wt = np.array([0, 0, 0, 1, 0, 0])
+state_cost = {
+    'type': CostState,
+    'l1': 0.0,
+    'l2': 10.0,
+    'alpha': 1e-5,
+    'data_types': {
+        JOINT_ANGLES: {
+            'target_state': cost_tgt,
+            'wp': cost_wt,
+        },
+    },
+}
+
+fk_cost_blocktouch = {
+    'type': CostFKBlock,
+    'wp': np.array([1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]),
+    'l1': 0.1,
+    'l2': 10.0,
+    'alpha': 1e-5,
+}
+
+algorithm['cost'] = [{
+    'type': CostSum,
+    'costs': [fk_cost[i], fk_cost_blocktouch, state_cost],
+    'weights': [4.0, 1.0, 1.0],
+} for i in xrange(common['conditions'])]
+
+
+algorithm['dynamics'] = {
+    'type': DynamicsLRPrior,
+    'regularization': 1e-6,
+    'prior': {
+        'type': DynamicsPriorGMM,
+        'max_clusters': 20,
+        'min_samples_per_cluster': 40,
+        'max_samples': 20,
+    },
+}
+
+algorithm['traj_opt'] = {
+    'type': TrajOptPILQR,
+    'kl_threshold': 1.0,
+    'covariance_damping': 10.0,
+}
+
+algorithm['policy_opt'] = {}
+
+config = {
+    'iterations': algorithm['iterations'],
+    'num_samples': 20,
+    'verbose_trials': 1,
+    'common': common,
+    'agent': agent,
+    'gui_on': True,
+    'algorithm': algorithm,
+    'random_seed': 0,
+}
+
+common['info'] = generate_experiment_info(config)

--- a/experiments/mjc_reacher_images/hyperparams.py
+++ b/experiments/mjc_reacher_images/hyperparams.py
@@ -20,7 +20,7 @@ from gps.algorithm.policy.lin_gauss_init import init_lqr, init_pd
 from gps.algorithm.policy_opt.policy_opt_caffe import PolicyOptCaffe
 from gps.algorithm.policy_opt.policy_opt_tf import PolicyOptTf
 from gps.algorithm.policy.policy_prior_gmm import PolicyPriorGMM
-from gps.algorithm.policy_opt.tf_model_example import example_tf_network
+from gps.algorithm.policy_opt.tf_model_example import tf_network
 from gps.algorithm.cost.cost_utils import RAMP_LINEAR, RAMP_FINAL_ONLY, RAMP_QUADRATIC, evall1l2term
 from gps.utility.data_logger import DataLogger
 from gps.algorithm.policy_opt.tf_model_example import multi_modal_network, multi_modal_network_fp

--- a/experiments/pr2_tensorflow_example/hyperparams.py
+++ b/experiments/pr2_tensorflow_example/hyperparams.py
@@ -25,7 +25,7 @@ from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, \
         TRIAL_ARM, AUXILIARY_ARM, JOINT_SPACE
 from gps.utility.general_utils import get_ee_points
 from gps.gui.config import generate_experiment_info
-from gps.algorithm.policy_opt.tf_model_example import example_tf_network
+from gps.algorithm.policy_opt.tf_model_example import tf_network
 
 
 EE_POINTS = np.array([[0.02, -0.025, 0.05], [0.02, -0.025, -0.05],
@@ -206,7 +206,7 @@ algorithm['policy_opt'] = {
         'obs_vector_data': [JOINT_ANGLES, JOINT_VELOCITIES],
         'sensor_dims': SENSOR_DIMS,
     },
-    'network_model': example_tf_network,
+    'network_model': tf_network,
     'iterations': 1000,
     'weights_file_prefix': EXP_DIR + 'policy',
 }

--- a/mjc_models/3link_gripper_pusher.xml
+++ b/mjc_models/3link_gripper_pusher.xml
@@ -1,0 +1,57 @@
+<mujoco model="arm3d">
+    <compiler inertiafromgeom="true" angle="radian" coordinate="local" />
+    <option timestep="0.01" gravity="0 0 0" iterations="20" integrator="RK4" />
+    <default>
+        <joint armature="0.04" damping="0.5" limited="true" />
+        <geom friction=".8 .1 .1" density="300" margin="0.002" condim="1" contype="1" conaffinity="1" />
+    </default>
+
+    <worldbody>
+        <body name="palm" pos="0 0 0">
+            <geom type="capsule" fromto="0 -0.1 0 0 0.1 0" size="0.12" />
+            <body name="proximal_1" pos="0 0 0">
+                <joint name="proximal_j_1" type="hinge" pos="0 0 0" axis="0 1 0" limited="false" />
+                <geom type="capsule"  fromto="0 0 0 0.4 0 0" size="0.06" contype="1" conaffinity="1" />
+                <body name="distal_1" pos="0.4 0 0">
+                    <joint name="distal_j_1" type="hinge" pos="0 0 0" axis="0 1 0" range="-2.3213 2.3" />
+                    <geom type="capsule"  fromto="0 0 0 0.4 0 0" size="0.06" contype="1" conaffinity="1" />
+                    <body name="distal_2" pos="0.4 0 0">
+                        <joint name="distal_j_2" type="hinge" pos="0 0 0" axis="0 1 0" range="-2.3213 2.3" />
+                        <geom type="capsule" fromto="0 0 0 0.4 0 0" size="0.06" contype="1" conaffinity="1" />
+                        <body name="distal_4" pos="0.4 0 0">
+                            <site name="tip arml" pos="0.1 0 -0.2" size="0.01" />
+                            <site name="tip armr" pos="0.1 0 0.2" size="0.01" />
+                            <joint name="distal_j_3" type="hinge" pos="0 0 0" axis="1 0 0" range="-3.3213 3.3" />
+                            <geom type="capsule" fromto="0 0 -0.2 0 0 0.2" size="0.04" contype="1" conaffinity="1" />
+                            <geom type="capsule" fromto="0 0 -0.2 0.2 0 -0.2" size="0.04" contype="1" conaffinity="1" />
+                            <geom type="capsule" fromto="0 0 0.2 0.2 0 0.2" size="0.04" contype="1" conaffinity="1" />
+                        </body>
+                    </body>
+                </body>
+            </body>
+        </body>
+        <body name="object" pos="0.0 0.0 0.0">
+            <geom rgba="1. 1. 1. 1" type="box" size="0.05 0.05 0.05" density='0.00001' contype="1" conaffinity="1" />
+            <joint name="obj_slidez" type="slide" pos="0.025 0.025 0.025" axis="0 0 1" range="-10.3213 10.3" damping="0.07" />
+            <joint name="obj_slidex" type="slide" pos="0.025 0.025 0.025" axis="1 0 0" range="-10.3213 10.3" damping="0.07" />
+            <body name="distal_10" pos="0 0 0">
+                <site name="obj_pos" pos="0.025 0.025 0.025" size="0.01" />
+            </body>
+        </body>
+
+        <body name="goal" pos="0 0 0">
+            <geom rgba="1. 0. 0. 1" type="box" size="0.1 0.1 0.1" density='0.00001' contype="0" conaffinity="0" />
+            <body name="distal_11" pos="0 0 0">
+                <site name="goal_pos" pos="0.05 0.05 0.05" size="0.01" />
+            </body>
+        </body>
+    </worldbody>
+
+    <actuator>
+        <motor joint="proximal_j_1" ctrlrange="-2 2" ctrllimited="true" />
+        <motor joint="distal_j_1" ctrlrange="-2 2" ctrllimited="true" />
+        <motor joint="distal_j_2" ctrlrange="-2 2" ctrllimited="true" />
+        <motor joint="distal_j_3" ctrlrange="-2 2" ctrllimited="true" />
+    </actuator>
+
+</mujoco>

--- a/mjc_models/pointmass_disc_cost.xml
+++ b/mjc_models/pointmass_disc_cost.xml
@@ -1,0 +1,34 @@
+<mujoco model="obstacle_course">
+    <!-- A 2D particle must first navigate toward the continous goal state, but 
+    then deviate towards the disconinuos goal region. -->
+
+    <compiler inertiafromgeom="true" angle="radian" coordinate="local" />
+    <option timestep="0.01" gravity="0 0 0" iterations="20" integrator="Euler" />
+    <default>
+        <joint limited="false" damping="1" />
+        <geom contype="2" conaffinity="1" condim="1" friction=".5 .1 .1" density="1000" margin="0.002" />
+    </default>
+
+    <worldbody>
+        <body name="particle" pos="0 0 0">
+            <geom name="particle_geom" type="capsule" fromto="-0.01 0 0 0.01 0 0" size="0.1" />
+            <site name="particle_site" pos="0 0 0" size="0.01" />
+            <joint name="ball_x" type="slide" pos="0 0 0" axis="1 0 0" />
+            <joint name="ball_y" type="slide" pos="0 0 0" axis="0 1 0" />
+        </body>
+        
+        <body name="disc_target" pos="2.5 0.5 0">
+            <geom name="disc_target_geom" type="capsule" fromto="-0.01 0 0 0.01 0 0" size="0.1" rgba="0.9 0 0.1 1"/>
+        </body>
+        
+        <body name="target" pos="3.0 0 0">
+            <geom name="target_geom" type="capsule" fromto="-0.01 0 0 0.01 0 0" size="0.1" rgba="0 0.9 0.1 1"/>
+        </body>
+
+    </worldbody>
+
+    <actuator>
+        <motor joint="ball_x" ctrlrange="-1.0 1.0" ctrllimited="true"/>
+        <motor joint="ball_y" ctrlrange="-1.0 1.0" ctrllimited="true"/>
+    </actuator>
+</mujoco>

--- a/mjc_models/pr2_arm3d_door.xml
+++ b/mjc_models/pr2_arm3d_door.xml
@@ -1,0 +1,111 @@
+<mujoco model="door">
+
+    <compiler inertiafromgeom="true" angle="radian" coordinate="local" />
+    <option timestep="0.01" gravity="0 0 0" iterations="20" integrator="RK4" />
+    <default>
+        <joint armature="0.04" damping="1" limited="true" />
+        <geom friction=".5 .1 .1" margin="0.002" condim="1" contype="0" conaffinity="0" />
+    </default>
+
+    <asset>
+        <texture type="skybox" builtin="gradient" width="100" height="100" rgb1=".4 .6 .8" rgb2="0 0 0"/>
+        <texture name="texgeom" type="cube" builtin="flat" mark="cross" width="127" height="1278" rgb1="0.8 0.6 0.4" rgb2="0.8 0.6 0.4" markrgb="1 1 1" random="0.01"/>
+        <texture name="texplane" type="2d" builtin="checker" rgb1=".2 .3 .4" rgb2=".1 0.15 0.2" width="100" height="100"/>
+
+        <material name='MatPlane' reflectance='0.5' texture="texplane" texrepeat="1 1" texuniform="true"/>
+        <material name='geom' texture="texgeom" texuniform="true"/>
+    </asset>
+
+    <worldbody>
+        <light directional='false' diffuse='.8 .8 .8' specular='0.3 0.3 0.3' pos='0 0 4.0' dir='0 0 -1'/>
+
+        <body name="r_shoulder_pan_link" pos="0.35 -0.35 0.5">
+            <geom name="e1" type="sphere" rgba="0.6 0.6 0.6 1" pos="-0.06 0.05 0.2" size="0.05" />
+            <geom name="e2" type="sphere" rgba="0.6 0.6 0.6 1" pos=" 0.06 0.05 0.2" size="0.05" />
+            <geom name="e1p" type="sphere" rgba="0.1 0.1 0.1 1" pos="-0.06 0.09 0.2" size="0.03" />
+            <geom name="e2p" type="sphere" rgba="0.1 0.1 0.1 1" pos=" 0.06 0.09 0.2" size="0.03" />
+            <geom name="sp" type="capsule" fromto="0 0 -0.4 0 0 0.2" size="0.1" />
+            <joint name="r_shoulder_pan_joint" type="hinge" pos="0 0 0" axis="0 0 1" range="-2.2854 1.714602" damping="1.0" />
+
+            <body name="r_shoulder_lift_link" pos="0.1 0 0" euler="0.0 -0.13 0.0">
+                <geom name="sl" type="capsule" fromto="0 -0.1 0 0 0.1 0" size="0.1" />
+                <joint name="r_shoulder_lift_joint" type="hinge" pos="0 0 0" axis="0 1 0" range="-0.5236 1.3963" damping="10.0" />
+
+                <body name="r_upper_arm_roll_link" pos="0 0 0">
+                    <geom name="uar" type="capsule" fromto="-0.1 0 0 0.1 0 0" size="0.02" />
+                    <joint name="r_upper_arm_roll_joint" type="hinge" pos="0 0 0" axis="1 0 0" range="-3.9 0.8" damping="0.1" />
+
+                    <body name="r_upper_arm_link" pos="0 0 0">
+                        <geom name="ua" type="capsule" fromto="0 0 0 0.4 0 0" size="0.06" />
+
+                        <body name="r_elbow_flex_link" pos="0.4 0 0" >
+                            <geom name="ef" type="capsule" fromto="0 -0.02 0 0.0 0.02 0" size="0.06" />
+                            <joint name="r_elbow_flex_joint" type="hinge" pos="0 0 0" axis="0 1 0" range="-2.3213 0" damping="1.0" />
+
+                            <body name="r_forearm_roll_link" pos="0 0 0" euler="0.0 0.0 0.8">
+                                <geom name="fr" type="capsule" fromto="-0.1 0 0 0.1 0 0" size="0.02" contype="1" conaffinity="1" />
+
+                                <body name="r_forearm_link" pos="0 0 0">
+                                    <geom name="fa" type="capsule" fromto="0 0 0 0.321 0 0" size="0.05" contype="1" conaffinity="1" />
+
+                                    <body name="r_wrist_flex_link" pos="0.321 0 0">
+                                        <geom name="wf" type="capsule" fromto="0 -0.02 0 0 0.02 0" size="0.01" contype="1" conaffinity="1" />
+                                        <joint name="r_wrist_flex_joint" type="hinge" pos="0 0 0" axis="0 1 0" range="-2.094 0" damping=".1" />
+
+                                        <body name="r_wrist_roll_link" pos="0 0 0" euler="0.0 0.0 0.2">
+                                            <geom name="wr" type="capsule" fromto="-0.02 0 0 0.02 0 0" size="0.01" contype="1" conaffinity="1" />
+                                            <joint name="r_wrist_roll_joint" type="hinge" pos="0 0 0" axis="1 0 0" range="-0.04 0.04" damping="10.0" />
+
+                                            <body name="r_gripper_palm_link" pos="0 0 0">
+                                                <geom name="pl" type="capsule" fromto="0.05 0 -0.02 0.05 0 0.02" size="0.05" contype="1" conaffinity="1" />
+
+                                                <body name="r_gripper_l_finger_link" pos="0.08 0.0 0">
+                                                    <geom name="gf" type="capsule" fromto="0 0 0 0.15 0 0" size="0.015" contype="1" conaffinity="1" />
+
+                                                    <body name="r_gripper_l_finger_tip_link" pos="0.15 0.0 0.0">
+                                                        <geom name="gft" type="capsule" fromto="0 0 0 0 0.0 -0.15" size="0.015" contype="1" conaffinity="1" />
+                                                        <site name="link_top" pos="0.0 0.0 0.0" size="0.01" />
+                                                        <site name="link_bottom" pos="0.0 0.0 -0.15" size="0.01" />
+                                                    </body>
+                                                </body>
+                                            </body>
+                                        </body>
+                                    </body>
+                                </body>
+                            </body>
+                        </body>
+                    </body>
+                </body>
+            </body>
+        </body>
+
+        <body name="door_frame" pos="0.35 0.50 0.30" euler="0.0 0.0 0.2">
+            <geom name="frame_left" rgba="0.3 0.3 0.3 1" type="box" size="0.05 0.02 0.60" pos="-0.555 0.0 0.00" contype="0" conaffinity="0" />
+            <geom name="frame_right" rgba="0.3 0.3 0.3 1" type="box" size="0.05 0.02 0.60" pos="0.555 0.0 0.00" contype="0" conaffinity="0" />
+            <geom name="frame_top" rgba="0.3 0.3 0.3 1" type="box" size="0.61 0.02 0.05" pos="0.0 0.0 0.655" contype="0" conaffinity="0" />
+        </body>
+
+        <body name="door" pos="0.35 0.50 0.30" euler="0.0 0.0 0.2">
+            <geom name="door" rgba="0.6 0.1 0.1 1" type="box" size="0.5 0.02 0.6" contype="1" conaffinity="1" />
+            <joint name="door_hinge" type="hinge" pos="-0.5 0.0 0.0" axis="0 0 1" range="-2.0 0.0" damping="5.0" />
+
+            <body name="door_handle" pos="0.15 -0.05 -0.25">
+                <geom name="handle_left" type="box" rgba="0.6 0.6 0.6 1" pos="0.08 0 0.2" size="0.02 0.08 0.02" contype="1" conaffinity="1" />
+                <geom name="handle_right" type="box" rgba="0.6 0.6 0.6 1" pos="0.27 0 0.2" size="0.02 0.08 0.02" contype="1" conaffinity="1" />
+                <geom name="handle_center" type="box" rgba="0.6 0.6 0.6 1" pos="0.175 -0.075 0.2" size="0.12 0.02 0.02" contype="1" conaffinity="1" />
+                <site name="above_handle" pos="0.175 0 0.25" size="0.01" />
+                <site name="handle" pos="0.175 0 0.10" size="0.01" />
+            </body>
+        </body>
+    </worldbody>
+
+    <actuator>
+        <motor joint="r_shoulder_pan_joint" ctrlrange="-100.0 100.0" ctrllimited="true" />
+        <motor joint="r_shoulder_lift_joint" ctrlrange="-100.0 100.0" ctrllimited="true" />
+        <motor joint="r_upper_arm_roll_joint" ctrlrange="-100.0 100.0" ctrllimited="true" />
+        <motor joint="r_elbow_flex_joint" ctrlrange="-100.0 100.0" ctrllimited="true" />
+        <motor joint="r_wrist_flex_joint" ctrlrange="-100.0 100.0" ctrllimited="true" />
+        <motor joint="r_wrist_roll_joint" ctrlrange="-100.0 100.0" ctrllimited="true" />
+    </actuator>
+
+</mujoco>

--- a/python/gps/agent/mjc/agent_mjc.py
+++ b/python/gps/agent/mjc/agent_mjc.py
@@ -12,7 +12,7 @@ from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, \
         END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, \
         END_EFFECTOR_POINT_JACOBIANS, ACTION, RGB_IMAGE, RGB_IMAGE_SIZE, \
         CONTEXT_IMAGE, CONTEXT_IMAGE_SIZE, IMAGE_FEAT, \
-        END_EFFECTOR_POINTS_NO_TARGET, END_EFFECTOR_POINT_VELOCITIES_NO_TARGET
+        END_EFFECTOR_POINTS_NO_TARGET, END_EFFECTOR_POINT_VELOCITIES_NO_TARGET, NOISE
 
 from gps.sample.sample import Sample
 
@@ -142,10 +142,10 @@ class AgentMuJoCo(Agent):
             if (t + 1) < self.T:
                 for _ in range(self._hyperparams['substeps']):
                     mj_X, _ = self._world[condition].step(mj_X, mj_U)
-                #TODO: Some hidden state stuff will go here.
                 self._data = self._world[condition].get_data()
                 self._set_sample(new_sample, mj_X, t, condition, feature_fn=feature_fn)
         new_sample.set(ACTION, U)
+        new_sample.set(NOISE, noise)
         if save:
             self._samples[condition].append(new_sample)
         return new_sample

--- a/python/gps/algorithm/algorithm_badmm.py
+++ b/python/gps/algorithm/algorithm_badmm.py
@@ -466,9 +466,12 @@ class AlgorithmBADMM(Algorithm):
 
         return predicted_cost, predicted_kl
 
-    def compute_costs(self, m, eta):
+    def compute_costs(self, m, eta, augment=True):
         """ Compute cost estimates used in the LQR backward pass. """
         traj_info, traj_distr = self.cur[m].traj_info, self.cur[m].traj_distr
+        if not augment:  # Whether to augment cost with term to penalize KL
+            return traj_info.Cm, traj_info.cv
+
         pol_info = self.cur[m].pol_info
         multiplier = self._hyperparams['max_ent_traj']
         T, dU, dX = traj_distr.T, traj_distr.dU, traj_distr.dX

--- a/python/gps/algorithm/algorithm_mdgps.py
+++ b/python/gps/algorithm/algorithm_mdgps.py
@@ -201,9 +201,12 @@ class AlgorithmMDGPS(Algorithm):
         for m in range(self.M):
             self._set_new_mult(predicted_impr, actual_impr, m)
 
-    def compute_costs(self, m, eta):
+    def compute_costs(self, m, eta, augment=True):
         """ Compute cost estimates used in the LQR backward pass. """
         traj_info, traj_distr = self.cur[m].traj_info, self.cur[m].traj_distr
+        if not augment:  # Whether to augment cost with term to penalize KL
+            return traj_info.Cm, traj_info.cv
+
         pol_info = self.cur[m].pol_info
         multiplier = self._hyperparams['max_ent_traj']
         T, dU, dX = traj_distr.T, traj_distr.dU, traj_distr.dX

--- a/python/gps/algorithm/algorithm_mdgps_pilqr.py
+++ b/python/gps/algorithm/algorithm_mdgps_pilqr.py
@@ -1,0 +1,105 @@
+""" This file defines the MDGPS with PI2 + LQR-based trajectory optimization method. """
+import copy
+import logging
+import numpy as np
+
+from gps.algorithm.algorithm import Algorithm
+from gps.algorithm.algorithm_mdgps import AlgorithmMDGPS
+from gps.algorithm.algorithm_traj_opt_pilqr import AlgorithmTrajOptPILQR
+from gps.algorithm.algorithm_utils import PolicyInfo
+from gps.algorithm.config import ALG_MDGPS_PILQR, ALG_MDGPS, ALG_PILQR
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AlgorithmMDGPSPILQR(AlgorithmMDGPS, AlgorithmTrajOptPILQR):
+    def __init__(self, hyperparams):
+        self.config_mdgps = copy.deepcopy(ALG_MDGPS_PILQR)
+        self.config_mdgps.update(hyperparams)
+
+        self.config_pilqr = copy.deepcopy(ALG_PILQR)
+        self.config_pilqr.update(hyperparams)
+
+        AlgorithmTrajOptPILQR.__init__(self, self.config_pilqr)
+        hyperparams = copy.deepcopy(self._hyperparams)
+        AlgorithmMDGPS.__init__(self, self.config_mdgps)
+        self._hyperparams.update(self._hyperparams)
+        del self.config_pilqr['agent']  # Don't want to pickle this.
+        del self.config_mdgps['agent']  # Don't want to pickle this.
+
+
+    def iteration(self, sample_lists):
+        """
+        Run iteration of PILQR.
+        Args:
+        sample_lists: List of SampleList objects for each condition.
+        """
+        for m in range(self.M):
+            self.cur[m].sample_list = sample_lists[m]
+            self._eval_cost(m)
+        
+        # Update dynamics model using all samples.
+        self._update_dynamics()
+        
+        # On the first iteration, need to catch policy up to init_traj_distr.
+        if self.iteration_count == 0:
+            self.new_traj_distr = [
+                self.cur[cond].traj_distr for cond in range(self.M)
+            ]
+            AlgorithmMDGPS._update_policy(self)
+        
+        # Update policy linearizations.
+        for m in range(self.M):
+            AlgorithmMDGPS._update_policy_fit(self, m)
+
+        # C-step
+        if self.iteration_count > 0:
+            for m in range(self.M):
+                AlgorithmTrajOptPILQR._stepadjust(self, m)
+		
+        self._update_trajectories()
+
+        # S-step
+        self._update_policy()
+
+        # Prepare for next iteration
+        self._advance_iteration_variables()
+
+    
+    def compute_costs_constrained(self, traj_distr, m, eta, augment=True):
+        """ Compute cost estimates used in the LQR backward pass. """
+        traj_info, traj_distr = self.cur[m].traj_info, traj_distr
+        if not augment:
+            return traj_info.Cm, traj_info.cv
+
+        pol_info = self.cur[m].pol_info
+        multiplier = self._hyperparams['max_ent_traj']
+        T, dU, dX = traj_distr.T, traj_distr.dU, traj_distr.dX
+        Cm, cv = np.copy(traj_info.Cm), np.copy(traj_info.cv)
+
+        PKLm = np.zeros((T, dX+dU, dX+dU))
+        PKLv = np.zeros((T, dX+dU)) 
+        fCm, fcv = np.zeros(Cm.shape), np.zeros(cv.shape)
+        for t in range(T):
+            # Policy KL-divergence terms.
+            inv_pol_S = np.linalg.solve(
+                pol_info.chol_pol_S[t, :, :],
+                np.linalg.solve(pol_info.chol_pol_S[t, :, :].T, np.eye(dU))
+            )
+            KB, kB = pol_info.pol_K[t, :, :], pol_info.pol_k[t, :]
+            PKLm[t, :, :] = np.vstack([
+                np.hstack([KB.T.dot(inv_pol_S).dot(KB), -KB.T.dot(inv_pol_S)]),
+                np.hstack([-inv_pol_S.dot(KB), inv_pol_S])
+            ])
+            PKLv[t, :] = np.concatenate([
+                KB.T.dot(inv_pol_S).dot(kB), -inv_pol_S.dot(kB)
+            ])
+            fCm[t, :, :] = (Cm[t, :, :] + PKLm[t, :, :] * eta) / (eta + multiplier)
+            fcv[t, :] = (cv[t, :] + PKLv[t, :] * eta) / (eta + multiplier)
+
+        return fCm, fcv
+    
+
+    def compute_costs(self, m, eta, augment=True):
+        return self.compute_costs_constrained(
+        	self.cur[m].traj_distr, m, eta, augment)

--- a/python/gps/algorithm/algorithm_mdgps_pilqr.py
+++ b/python/gps/algorithm/algorithm_mdgps_pilqr.py
@@ -27,7 +27,6 @@ class AlgorithmMDGPSPILQR(AlgorithmMDGPS, AlgorithmTrajOptPILQR):
         del self.config_pilqr['agent']  # Don't want to pickle this.
         del self.config_mdgps['agent']  # Don't want to pickle this.
 
-
     def iteration(self, sample_lists):
         """
         Run iteration of PILQR.
@@ -65,11 +64,10 @@ class AlgorithmMDGPSPILQR(AlgorithmMDGPS, AlgorithmTrajOptPILQR):
         # Prepare for next iteration
         self._advance_iteration_variables()
 
-    
-    def compute_costs_constrained(self, traj_distr, m, eta, augment=True):
+    def compute_costs(self, m, eta, augment=True):
         """ Compute cost estimates used in the LQR backward pass. """
-        traj_info, traj_distr = self.cur[m].traj_info, traj_distr
-        if not augment:
+        traj_info, traj_distr = self.cur[m].traj_info, self.cur[m].traj_distr
+        if not augment:  # Whether to augment cost with term to penalize KL
             return traj_info.Cm, traj_info.cv
 
         pol_info = self.cur[m].pol_info
@@ -98,8 +96,3 @@ class AlgorithmMDGPSPILQR(AlgorithmMDGPS, AlgorithmTrajOptPILQR):
             fcv[t, :] = (cv[t, :] + PKLv[t, :] * eta) / (eta + multiplier)
 
         return fCm, fcv
-    
-
-    def compute_costs(self, m, eta, augment=True):
-        return self.compute_costs_constrained(
-        	self.cur[m].traj_distr, m, eta, augment)

--- a/python/gps/algorithm/algorithm_traj_opt.py
+++ b/python/gps/algorithm/algorithm_traj_opt.py
@@ -98,9 +98,12 @@ class AlgorithmTrajOpt(Algorithm):
 
         self._set_new_mult(predicted_impr, actual_impr, m)
 
-    def compute_costs(self, m, eta):
+    def compute_costs(self, m, eta, augment=True):
         """ Compute cost estimates used in the LQR backward pass. """
         traj_info, traj_distr = self.cur[m].traj_info, self.cur[m].traj_distr
+        if not augment:  # Whether to augment cost with term to penalize KL
+            return traj_info.Cm, traj_info.cv
+
         multiplier = self._hyperparams['max_ent_traj']
         fCm, fcv = traj_info.Cm / (eta + multiplier), traj_info.cv / (eta + multiplier)
         K, ipc, k = traj_distr.K, traj_distr.inv_pol_covar, traj_distr.k

--- a/python/gps/algorithm/algorithm_traj_opt_pi2.py
+++ b/python/gps/algorithm/algorithm_traj_opt_pi2.py
@@ -6,7 +6,7 @@ from gps.algorithm.algorithm import Algorithm
 from gps.algorithm.config import ALG_PI2
 
 
-class AlgorithmTrajOptPi2(Algorithm):
+class AlgorithmTrajOptPI2(Algorithm):
     """ Sample-based trajectory optimization with PI2. """
     def __init__(self, hyperparams):
         config = copy.deepcopy(ALG_PI2)

--- a/python/gps/algorithm/algorithm_traj_opt_pilqr.py
+++ b/python/gps/algorithm/algorithm_traj_opt_pilqr.py
@@ -1,0 +1,166 @@
+""" This file defines the PILQR-based algorithm. """
+import copy
+import logging
+import numpy as np
+
+from gps.algorithm.algorithm import Algorithm
+from gps.algorithm.config import ALG_PILQR
+
+from gps.algorithm.traj_opt.traj_opt_utils import approximated_cost
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AlgorithmTrajOptPILQR(Algorithm):
+    def __init__(self, hyperparams):
+        config = copy.deepcopy(ALG_PILQR)
+        config.update(hyperparams)
+        Algorithm.__init__(self, config)
+
+    def iteration(self, sample_lists):
+        """
+        Run iteration of PILQR.
+        Args:
+            sample_lists: List of SampleList objects for each condition.
+        """
+        for m in range(self.M):
+            self.cur[m].sample_list = sample_lists[m]
+
+        # Update dynamics model using all samples.
+        self._update_dynamics()
+
+        self._update_step_size()  # KL Divergence step size.
+
+        # Run inner loop to compute new policies.
+        for _ in range(self._hyperparams['inner_iterations']):
+            self._update_trajectories()
+            self._advance_iteration_variables()
+
+    def _update_step_size(self):
+        """ Evaluate costs on samples, and adjust the step size. """
+        # Evaluate cost function for all conditions and samples.
+        for m in range(self.M):
+            self._eval_cost(m)
+
+        # Adjust step size relative to the previous iteration.
+        for m in range(self.M):
+            if self.iteration_count >= 1 and self.prev[m].sample_list:
+                self._stepadjust(m)
+
+    def _compute_step_pi2_lqr(self, m, pdpc, pdcc, cdcc, pmc, cmc, cur_res):
+        """
+        Calculate new step size for pi2 and lqr.
+        Args:
+        m: condition
+        pdpc: previous dynamics-previous controller cost
+        pdcc: previous dynamics-current controller cost
+        cdcc: current dynamics-current controller cost
+        pmc: previous actual cost
+        cmc: current actual cost
+        cur_res:
+        """
+
+    def _stepadjust(self, m):
+        """
+        Calculate new step sizes.
+        Args:
+            m: Condition
+        """
+        pdpc = self.traj_opt.estimate_cost(
+                self.prev[m].traj_distr, self.prev[m].traj_info
+        )
+        pdcc = self.traj_opt.estimate_cost(
+                self.cur[m].traj_distr, self.prev[m].traj_info
+        )
+        cdcc = self.traj_opt.estimate_cost(
+                self.cur[m].traj_distr, self.cur[m].traj_info
+        )
+
+        ent = self._measure_ent(m)
+
+        pmc = np.mean(np.sum(self.prev[m].cs, axis=1), axis=0)
+        cmc = np.mean(np.sum(self.cur[m].cs, axis=1), axis=0)
+
+        LOGGER.debug('Trajectory step: ent: %f cost: %f -> %f',
+                     ent, pmc, cmc)
+
+        _, cur_c_approx = approximated_cost(
+                self.cur[m].sample_list, self.cur[m].traj_distr,
+                self.cur[m].traj_info
+        )
+        cur_res = cur_c_approx - self.cur[m].cs
+
+        LOGGER.debug('Previous cost: Laplace: %f MC: %f', np.sum(pdpc), pmc)
+        LOGGER.debug('Predicted new cost: Laplace: %f MC: %f', np.sum(pdcc), cmc)
+        LOGGER.debug('Actual new cost: Laplace: %f MC: %f', np.sum(cdcc), cmc)
+
+        max_mult = self._hyperparams['max_step_mult']
+        min_mult = self._hyperparams['min_step_mult']
+
+        if self._hyperparams['step_rule'] == 'const':
+            self.cur[m].step_mult = self.prev[m].step_mult
+        elif self._hyperparams['step_rule'] == 'res_percent':
+            cur_res_sum = np.mean(np.sum(np.abs(cur_res), axis=1))
+            act_sum = np.mean(np.sum(np.abs(self.cur[m].cs), axis=1))
+            # Print cost details.
+            LOGGER.debug(
+                    'Cur residuals: %f. Residuals percentage: %f',
+                    cur_res_sum, cur_res_sum/act_sum*100
+            )
+            if self.traj_opt.cons_per_step:
+                T = cur_res.shape[1]
+                new_mult = np.ones(T)
+                for t in range(T):
+                    res = np.mean(np.sum(np.abs(cur_res[:, t:]), axis=1))
+                    act = np.mean(np.sum(np.abs(self.cur[m].cs[:, t:]), axis=1))
+                    if res/act > self._hyperparams['step_rule_res_ratio_dec']:
+                        new_mult[t] = 0.5
+                    elif res/act < self._hyperparams['step_rule_res_ratio_inc']:
+                        new_mult[t] = 2.0
+            else:
+                if cur_res_sum/act_sum > self._hyperparams['step_rule_res_ratio_dec']:
+                    new_mult = 0.5
+                elif cur_res_sum/act_sum < self._hyperparams['step_rule_res_ratio_inc']:
+                    new_mult = 2.0
+                else:
+                    new_mult = 1
+            new_step = np.maximum(
+                    np.minimum(new_mult * self.cur[m].step_mult, max_mult),
+                    min_mult
+            )
+            self.cur[m].step_mult = new_step
+        else:
+            raise NotImplementedError('Unknown step adjustment rule.')
+
+    def _compute_costs(self, traj_distr, m, eta, augment=True):
+        """ Compute cost estimates used in the LQR backward pass. """
+
+        traj_info, traj_distr = self.cur[m].traj_info, traj_distr
+        if not augment:
+            return traj_info.Cm, traj_info.cv
+
+        multiplier = self._hyperparams['max_ent_traj']
+        fCm, fcv = traj_info.Cm / (eta + multiplier), traj_info.cv / (eta + multiplier)
+        K, ipc, k = traj_distr.K, traj_distr.inv_pol_covar, traj_distr.k
+
+        # Add in the trajectory divergence term.
+        for t in range(self.T - 1, -1, -1):
+            fCm[t, :, :] += eta / (eta + multiplier) * np.vstack([
+                np.hstack([
+                    K[t, :, :].T.dot(ipc[t, :, :]).dot(K[t, :, :]),
+                    -K[t, :, :].T.dot(ipc[t, :, :])
+                ]),
+                np.hstack([
+                    -ipc[t, :, :].dot(K[t, :, :]), ipc[t, :, :]
+                ])
+            ])
+            fcv[t, :] += eta / (eta + multiplier) * np.hstack([
+                K[t, :, :].T.dot(ipc[t, :, :]).dot(k[t, :]),
+                -ipc[t, :, :].dot(k[t, :])
+            ])
+
+        return fCm, fcv
+
+    def compute_costs(self, m, eta, augment=True):
+        return self._compute_costs(self.cur[m].traj_distr, m, eta, augment)

--- a/python/gps/algorithm/config.py
+++ b/python/gps/algorithm/config.py
@@ -1,5 +1,8 @@
 """ Default configuration and hyperparameter values for algorithms. """
 
+import numpy as np
+
+
 # Algorithm
 ALG = {
     'inner_iterations': 1,  # Number of iterations.
@@ -8,6 +11,8 @@ ALG = {
     'kl_step':0.2,
     'min_step_mult':0.01,
     'max_step_mult':10.0,
+    'min_mult': 0.1,
+    'max_mult': 5.0,
     # Trajectory settings.
     'initial_state_var':1e-6,
     'init_traj_distr': None,  # A list of initial LinearGaussianPolicy
@@ -43,7 +48,8 @@ ALG_BADMM = {
     'exp_step_lower': 1.0,
 }
 
-# AlgorithmMD
+
+# AlgorithmMDGPS
 ALG_MDGPS = {
     # TODO: remove need for init_pol_wt in MDGPS
     'init_pol_wt': 0.01,
@@ -52,11 +58,13 @@ ALG_MDGPS = {
     'step_rule': 'laplace',
 }
 
-# AlgorithmTrajOptPi2
+
+# AlgorithmTrajOptPI2
 ALG_PI2 = {
     # Dynamics fitting is not required for PI2.
     'fit_dynamics': False,
 }
+
 
 # AlgorithmPIGPS
 ALG_PIGPS = {    
@@ -64,4 +72,41 @@ ALG_PIGPS = {
     'policy_sample_mode': 'add',    
     # Dynamics fitting is not required for PIGPS.
     'fit_dynamics': False,
+}
+
+
+# AlgorithmPILQR
+ALG_PILQR = {
+    'init_pol_wt': 0.01,
+    # Dynamics fitting is not required for PI2 but it is for LQR.
+    'fit_dynamics': True,
+    # Whether to use 'const' or 'res_percent' in step adjusment
+    'step_rule': 'res_percent',
+    'step_rule_res_ratio_dec': 0.2,
+    'step_rule_res_ratio_inc': 0.05,
+    # The following won't work for a different horizon, but that's up to the user.
+    'kl_step': np.linspace(0.4, 0.2, 100),
+    'max_step_mult': np.linspace(10.0, 5.0, 100),
+    'min_step_mult': np.linspace(0.01, 0.5, 100),
+    'max_mult': np.linspace(5.0, 2.0, 100),
+    'min_mult': np.linspace(0.1, 0.5, 100),
+}
+
+
+ALG_MDGPS_PILQR = {
+    # TODO: remove need for init_pol_wt in MDGPS
+    'init_pol_wt': 0.01,
+    'policy_sample_mode': 'add',
+    # Dynamics fitting is not required for PI2 but it is for LQR.
+    'fit_dynamics': True,
+    # Whether to use 'const' or 'res_percent' in step adjusment
+    'step_rule': 'res_percent',
+    'step_rule_res_ratio_dec': 0.2,
+    'step_rule_res_ratio_inc': 0.05,
+    # The following won't work for a different horizon, but that's up to the user.
+    'kl_step': np.linspace(0.4, 0.2, 100),
+    'max_step_mult': np.linspace(10.0, 5.0, 100),
+    'min_step_mult': np.linspace(0.01, 0.5, 100),
+    'max_mult': np.linspace(5.0, 2.0, 100),
+    'min_mult': np.linspace(0.1, 0.5, 100),
 }

--- a/python/gps/algorithm/cost/config.py
+++ b/python/gps/algorithm/cost/config.py
@@ -33,6 +33,23 @@ COST_STATE = {
     },
 }
 
+# CostBinaryRegion
+COST_BINARY_REGION = {
+    'ramp_option': RAMP_CONSTANT,  # How target cost ramps over time.
+    'l1': 0.0,
+    'l2': 1.0,
+    'alpha': 1e-2,
+    'wp_final_multiplier': 1.0,  # Weight multiplier on final time step.
+    'data_types': {
+        'JointAngle': {
+            'target_state': None,  # Target state - must be set.
+            'wp': None,  # State weights - must be set.
+        },
+    },
+    'max_distance': 0.1,
+    'outside_cost': 1.0,
+    'inside_cost': 0.0,
+}
 
 # CostSum
 COST_SUM = {
@@ -44,4 +61,16 @@ COST_SUM = {
 # CostAction
 COST_ACTION = {
     'wu': np.array([]),  # Torque penalties, must be 1 x dU numpy array.
+}
+
+
+# CostLinWP
+COST_LIN_WP = {
+    'waypoint_time': np.array([1.0]),
+    'ramp_option': RAMP_CONSTANT,
+    'l1': 0.0,
+    'l2': 1.0,
+    'alpha': 1e-5,
+    'logalpha': 1e-5,
+    'log': 0.0,
 }

--- a/python/gps/algorithm/cost/cost_binary_region.py
+++ b/python/gps/algorithm/cost/cost_binary_region.py
@@ -1,0 +1,64 @@
+""" This file defines the binary region cost. """
+import copy
+
+import numpy as np
+
+from gps.algorithm.cost.config import COST_BINARY_REGION
+from gps.algorithm.cost.cost import Cost
+from gps.algorithm.cost.cost_utils import evall1l2term, get_ramp_multiplier
+
+
+class CostBinaryRegion(Cost):
+    """ Computes binary cost that determines if the object 
+    is inside the given region around the target state.
+    """
+    def __init__(self, hyperparams):
+        config = copy.deepcopy(COST_BINARY_REGION)
+        config.update(hyperparams)
+        Cost.__init__(self, config)
+
+    def eval(self, sample):
+        """
+        Evaluate cost function and derivatives on a sample.
+        Args:
+            sample:  A single sample
+        """
+        T = sample.T
+        Du = sample.dU
+        Dx = sample.dX
+
+        final_l = np.zeros(T)
+        final_lu = np.zeros((T, Du))
+        final_lx = np.zeros((T, Dx))
+        final_luu = np.zeros((T, Du, Du))
+        final_lxx = np.zeros((T, Dx, Dx))
+        final_lux = np.zeros((T, Du, Dx))
+
+        tt_total = 0
+        for data_type in self._hyperparams['data_types']:
+            config = self._hyperparams['data_types'][data_type]
+            wp = config['wp']
+            tgt = config['target_state']
+            max_distance = config['max_distance']
+            outside_cost = config['outside_cost']
+            inside_cost = config['inside_cost']
+            x = sample.get(data_type)
+            _, dim_sensor = x.shape
+
+            wpm = get_ramp_multiplier(
+                self._hyperparams['ramp_option'], T,
+                wp_final_multiplier=self._hyperparams['wp_final_multiplier']
+            )
+            wp = wp * np.expand_dims(wpm, axis=-1)
+
+            # Compute binary region penalty.
+            dist = np.abs(x - tgt)
+            for t in xrange(T):
+                # If at least one of the coordinates is outside of 
+                # the region assign outside_cost, otherwise inside_cost.
+                if np.sum(dist[t]) > max_distance:
+                    final_l[t] += outside_cost
+                else:
+                    final_l[t] += inside_cost 
+
+        return final_l, final_lx, final_lu, final_lxx, final_luu, final_lux

--- a/python/gps/algorithm/cost/cost_fk_blocktouch.py
+++ b/python/gps/algorithm/cost/cost_fk_blocktouch.py
@@ -1,0 +1,56 @@
+# TODO: This cost function is hard-coded and not easy to generalize.
+import copy
+
+import numpy as np
+
+from gps.algorithm.cost.config import COST_FK
+from gps.algorithm.cost.cost import Cost
+from gps.algorithm.cost.cost_utils import get_ramp_multiplier
+from gps.proto.gps_pb2 import JOINT_ANGLES, END_EFFECTOR_POINTS, \
+        END_EFFECTOR_POINT_JACOBIANS
+
+
+class CostFKBlock(Cost):
+    def __init__(self, hyperparams):
+        config = copy.deepcopy(COST_FK)
+        config.update(hyperparams)
+        Cost.__init__(self, config)
+
+    def eval(self, sample):
+        T = sample.T
+        dX = sample.dX
+        dU = sample.dU
+
+        wpm = get_ramp_multiplier(
+            self._hyperparams['ramp_option'], T,
+            wp_final_multiplier=self._hyperparams['wp_final_multiplier']
+        )
+        wp = self._hyperparams['wp'] * np.expand_dims(wpm, axis=-1)
+
+        l = np.zeros(T)
+        lu = np.zeros((T, dU))
+        lx = np.zeros((T, dX))
+        luu = np.zeros((T, dU, dU))
+        lxx = np.zeros((T, dX, dX))
+        lux = np.zeros((T, dU, dX))
+
+        pt = sample.get(END_EFFECTOR_POINTS)
+        pt_ee_l = pt[:, 0:3]
+        pt_ee_r = pt[:, 3:6]
+        pt_ee_avg = 0.5 * (pt_ee_r + pt_ee_l)
+        pt_block = pt[:, 6:9]
+        dist = pt_ee_avg - pt_block
+        wp = np.ones((T,3))
+        jx = sample.get(END_EFFECTOR_POINT_JACOBIANS)
+        jx_1 = 0.5 * (jx[:, 0:3, :] + jx[:, 3:6, :]) - jx[:, 6:9, :]
+        jxx_zeros = np.zeros((T, dist.shape[1], jx.shape[2], jx.shape[2]))
+        l, ls, lss = self._hyperparams['evalnorm'](
+            wp, dist, jx_1, jxx_zeros, self._hyperparams['l1'],
+            self._hyperparams['l2'], self._hyperparams['alpha']
+        )
+
+        sample.agent.pack_data_x(lx, ls, data_types=[JOINT_ANGLES])
+        sample.agent.pack_data_x(lxx, lss,
+                                 data_types=[JOINT_ANGLES, JOINT_ANGLES])
+
+        return l, lx, lu, lxx, luu, lux

--- a/python/gps/algorithm/cost/cost_fk_blocktouch.py
+++ b/python/gps/algorithm/cost/cost_fk_blocktouch.py
@@ -11,6 +11,8 @@ from gps.proto.gps_pb2 import JOINT_ANGLES, END_EFFECTOR_POINTS, \
 
 
 class CostFKBlock(Cost):
+    """Computes cost for gripper pusher based on distance from gripper to block.
+    """
     def __init__(self, hyperparams):
         config = copy.deepcopy(COST_FK)
         config.update(hyperparams)
@@ -35,14 +37,21 @@ class CostFKBlock(Cost):
         lux = np.zeros((T, dU, dX))
 
         pt = sample.get(END_EFFECTOR_POINTS)
+
+        # The following is hard-coded: determines position of gripper and block
+        # and computes the distance between them
         pt_ee_l = pt[:, 0:3]
         pt_ee_r = pt[:, 3:6]
         pt_ee_avg = 0.5 * (pt_ee_r + pt_ee_l)
         pt_block = pt[:, 6:9]
         dist = pt_ee_avg - pt_block
+
         wp = np.ones((T,3))
         jx = sample.get(END_EFFECTOR_POINT_JACOBIANS)
+
+        # Also hard-coded is this Jacobian calculation
         jx_1 = 0.5 * (jx[:, 0:3, :] + jx[:, 3:6, :]) - jx[:, 6:9, :]
+
         jxx_zeros = np.zeros((T, dist.shape[1], jx.shape[2], jx.shape[2]))
         l, ls, lss = self._hyperparams['evalnorm'](
             wp, dist, jx_1, jxx_zeros, self._hyperparams['l1'],

--- a/python/gps/algorithm/cost/cost_lin_wp.py
+++ b/python/gps/algorithm/cost/cost_lin_wp.py
@@ -1,0 +1,113 @@
+""" This file defines an arbitrary linear waypoint cost. """
+import copy
+
+import numpy as np
+
+from gps.algorithm.cost.config import COST_LIN_WP
+from gps.algorithm.cost.cost import Cost
+from gps.algorithm.cost.cost_utils import evall1l2term, get_ramp_multiplier
+
+
+class CostLinWP(Cost):
+    """ Computes an arbitrary linear waypoint cost. """
+    def __init__(self, hyperparams):
+        config = copy.deepcopy(COST_LIN_WP)
+        config.update(hyperparams)
+        Cost.__init__(self, config)
+
+    def eval(self, sample):
+        """
+        Evaluate cost function and derivatives on a sample.
+        Args:
+            sample:  A single sample
+        """
+        T, dU, dX = sample.T, sample.dU, sample.dX
+        orig_A, orig_b = self._hyperparams['A'], self._hyperparams['b']
+
+        # Discretize waypoint time steps.
+        waypoint_step = np.ceil(T * self._hyperparams['waypoint_time'])
+        A = np.zeros((T, dX+dU, dX+dU))
+        b = np.zeros((T, dX+dU))
+
+        if not isinstance(self._hyperparams['ramp_option'], list):
+            self._hyperparams['ramp_option'] = [
+                self._hyperparams['ramp_option'] for _ in waypoint_step
+            ]
+
+        # Set up time-varying matrix and vector.
+        start = 0
+        for i in range(len(waypoint_step)):
+            wpm = get_ramp_multiplier(self._hyperparams['ramp_option'][i],
+                                      waypoint_step[i] - start)
+            for t in range(start, int(waypoint_step[i])):
+                A[t, :, :] = wpm[t-start] * orig_A[i, :, :]
+                b[t, :] = wpm[t-start] * orig_b[i, :]
+            start = int(waypoint_step[i])
+
+        # Evaluate distance function.
+        XU = np.concatenate([sample.get_X(), sample.get_U()], axis=1)
+        dist = np.zeros((T, dX+dU))
+        for t in range(T):
+            dist[t, :] = A[t, :, :].dot(XU[t, :]) + b[t, :]
+
+        ix, iu = slice(dX), slice(dX, dX+dU)
+        # Compute the loss.
+        Al, Aly, Alyy = self._evalloss(dist)
+        Alx = Aly[:, ix]
+        Alu = Aly[:, iu]
+        Alxx = Alyy[:, ix, ix]
+        Aluu = Alyy[:, iu, iu]
+        Alux = Alyy[:, ix, iu]
+
+        # Compute state derivatives and value. Loss is the same.
+        l = Al
+        # First derivative given by A'*Aly.
+        # Second derivative given by A'*Alyy*A.
+        lx, lu = np.zeros((T, dX)), np.zeros((T, dU))
+        lxx, luu = np.zeros((T, dX, dX)), np.zeros((T, dU, dU))
+        lux = np.zeros((T, dU, dX))
+        for t in range(T):
+            lx[t, :] = A[t, ix, ix].T.dot(Alx[t, :])
+            lu[t, :] = A[t, iu, iu].T.dot(Alu[t, :])
+            lxx[t, :, :] = A[t, ix, ix].T.dot(Alxx[t, :, :]).dot(A[t, ix, ix])
+            luu[t, :, :] = A[t, iu, iu].T.dot(Aluu[t, :, :]).dot(A[t, iu, iu])
+            lux[t, :, :] = A[t, ix, iu].T.dot(Alux[t, :, :]).dot(A[t, iu, ix])
+
+        return l, lx, lu, lxx, luu, lux
+
+    def _evalloss(self, dist):
+        T = dist.shape[0]
+        l1, l2 = self._hyperparams['l1'], self._hyperparams['l2']
+        alpha = self._hyperparams['alpha']
+        logalpha, log = self._hyperparams['logalpha'], self._hyperparams['log']
+
+        # Compute total cost.
+        l = 0.5 * np.sum(dist ** 2, axis=1) * l2 + \
+                np.sqrt(alpha + np.sum(dist ** 2, axis=1)) * l1 + \
+                0.5 * np.log(logalpha + np.sum(dist ** 2, axis=1)) * log
+
+        # First order derivative terms.
+        lx = dist * l2 + (
+            dist / np.sqrt(alpha + np.sum(dist**2, axis=1, keepdims=True)) * l1
+        ) + (dist / (logalpha + np.sum(dist ** 2, axis=1, keepdims=True)) * log)
+
+        # Second order derivative terms.
+        psq = np.expand_dims(
+            np.sqrt(alpha + np.sum(dist ** 2, axis=1, keepdims=True)), axis=1
+        )
+        psqlog = np.expand_dims(
+            logalpha + np.sum(dist ** 2, axis=1, keepdims=True), axis=1
+        )
+        lxx = l1 * (
+            (np.expand_dims(np.eye(dist.shape[1]), axis=0) / psq) -
+            ((np.expand_dims(dist, axis=1) *
+              np.expand_dims(dist, axis=2)) / psq ** 3)
+        )
+        lxx += l2 * np.tile(np.eye(dist.shape[1]), [T, 1, 1])
+        lxx += log * (
+            (np.expand_dims(np.eye(dist.shape[1]), axis=0) / psqlog) -
+            ((np.expand_dims(dist, axis=1) *
+              np.expand_dims(dist, axis=2)) / psq ** 2)
+        )
+
+        return l, lx, lxx

--- a/python/gps/algorithm/policy_opt/tf_model_example.py
+++ b/python/gps/algorithm/policy_opt/tf_model_example.py
@@ -90,6 +90,29 @@ def example_tf_network(dim_input=27, dim_output=7, batch_size=25, network_config
     return TfMap.init_from_lists([nn_input, action, precision], [mlp_applied], [loss_out]), fc_vars, []
 
 
+def tf_network(dim_input=27, dim_output=7, batch_size=25, network_config=None):
+    """
+    An example of how one might want to specify a network in tensorflow.
+
+    Args:
+        dim_input: Dimensionality of input.
+        dim_output: Dimensionality of the output.
+        batch_size: Batch size.
+    Returns:
+        a TfMap object used to serialize, inputs, outputs, and loss.
+    """
+    n_layers = network_config['n_layers'] + 1
+    dim_hidden = network_config['dim_hidden']
+    dim_hidden.append(dim_output)
+
+    nn_input, action, precision = get_input_layer(dim_input, dim_output)
+    mlp_applied, weights_FC, biases_FC = get_mlp_layers(nn_input, n_layers, dim_hidden)
+    fc_vars = weights_FC + biases_FC
+    loss_out = get_loss_layer(mlp_out=mlp_applied, action=action, precision=precision, batch_size=batch_size)
+
+    return TfMap.init_from_lists([nn_input, action, precision], [mlp_applied], [loss_out]), fc_vars, []
+
+
 def multi_modal_network(dim_input=27, dim_output=7, batch_size=25, network_config=None):
     """
     An example a network in tf that has both state and image inputs.

--- a/python/gps/algorithm/policy_opt/tf_model_example.py
+++ b/python/gps/algorithm/policy_opt/tf_model_example.py
@@ -67,42 +67,20 @@ def get_loss_layer(mlp_out, action, precision, batch_size):
     return euclidean_loss_layer(a=action, b=mlp_out, precision=precision, batch_size=batch_size)
 
 
-def example_tf_network(dim_input=27, dim_output=7, batch_size=25, network_config=None):
+def tf_network(dim_input=27, dim_output=7, batch_size=25, network_config):
     """
-    An example of how one might want to specify a network in tensorflow.
+    Specifying a fully-connected network in TensorFlow.
 
     Args:
         dim_input: Dimensionality of input.
         dim_output: Dimensionality of the output.
         batch_size: Batch size.
+        network_config: dictionary of network structure parameters
     Returns:
         a TfMap object used to serialize, inputs, outputs, and loss.
     """
-    n_layers = 2
-    dim_hidden = (n_layers - 1) * [40]
-    dim_hidden.append(dim_output)
-
-    nn_input, action, precision = get_input_layer(dim_input, dim_output)
-    mlp_applied, weights_FC, biases_FC = get_mlp_layers(nn_input, n_layers, dim_hidden)
-    fc_vars = weights_FC + biases_FC
-    loss_out = get_loss_layer(mlp_out=mlp_applied, action=action, precision=precision, batch_size=batch_size)
-
-    return TfMap.init_from_lists([nn_input, action, precision], [mlp_applied], [loss_out]), fc_vars, []
-
-
-def tf_network(dim_input=27, dim_output=7, batch_size=25, network_config=None):
-    """
-    An example of how one might want to specify a network in tensorflow.
-
-    Args:
-        dim_input: Dimensionality of input.
-        dim_output: Dimensionality of the output.
-        batch_size: Batch size.
-    Returns:
-        a TfMap object used to serialize, inputs, outputs, and loss.
-    """
-    n_layers = network_config['n_layers'] + 1
-    dim_hidden = network_config['dim_hidden']
+    n_layers = 2 if 'n_layers' not in network_config else network_config['n_layers']
+    dim_hidden = (n_layers - 1) * [40] if 'dim_hidden' not in network_config else network_config['dim_hidden']
     dim_hidden.append(dim_output)
 
     nn_input, action, precision = get_input_layer(dim_input, dim_output)

--- a/python/gps/algorithm/traj_opt/config.py
+++ b/python/gps/algorithm/traj_opt/config.py
@@ -6,13 +6,28 @@ TRAJ_OPT_LQR = {
     # Dual variable updates for non-PD Q-function.
     'del0': 1e-4,
     'eta_error_threshold': 1e16,
-    'min_eta': 1e-4,
+    'min_eta': 1e-8,
     'max_eta': 1e16,
+    'cons_per_step': False,  # Whether or not to enforce separate KL constraints at each time step.
+    'use_prev_distr': False,  # Whether or not to measure expected KL under the previous traj distr.
+    'update_in_bwd_pass': True,  # Whether or not to update the TVLG controller during the bwd pass.
 }
 
-# TrajOptPi2
+# TrajOptPI2
 TRAJ_OPT_PI2 = {  
     'kl_threshold': 1.0,    
     'covariance_damping': 2.0,
     'min_temperature': 0.001,
+    'use_sumexp': False,
+    'pi2_use_dgd_eta': False,
+    'pi2_cons_per_step': True,
+    'min_eta': 1e-8,
+    'max_eta': 1e16,
+    'del0': 1e-4,
+}
+
+# TrajOptPILQR
+TRAJ_OPT_PILQR = {
+    'use_lqr_actions': True,
+    'cons_per_step': True,
 }

--- a/python/gps/algorithm/traj_opt/traj_opt_lqr_python.py
+++ b/python/gps/algorithm/traj_opt/traj_opt_lqr_python.py
@@ -9,12 +9,16 @@ import scipy as sp
 from gps.algorithm.traj_opt.config import TRAJ_OPT_LQR
 from gps.algorithm.traj_opt.traj_opt import TrajOpt
 from gps.algorithm.traj_opt.traj_opt_utils import \
-        traj_distr_kl, DGD_MAX_ITER
+        DGD_MAX_ITER, DGD_MAX_LS_ITER, DGD_MAX_GD_ITER, \
+        ALPHA, BETA1, BETA2, EPS, \
+        traj_distr_kl, traj_distr_kl_alt
 
 from gps.algorithm.algorithm_badmm import AlgorithmBADMM
 from gps.algorithm.algorithm_mdgps import AlgorithmMDGPS
 
+
 LOGGER = logging.getLogger(__name__)
+
 
 class TrajOptLQRPython(TrajOpt):
     """ LQR trajectory optimization, Python implementation. """
@@ -24,15 +28,21 @@ class TrajOptLQRPython(TrajOpt):
 
         TrajOpt.__init__(self, config)
 
+        self.cons_per_step = config['cons_per_step']
+        self._use_prev_distr = config['use_prev_distr']
+        self._update_in_bwd_pass = config['update_in_bwd_pass']
+
     # TODO - Add arg and return spec on this function.
     def update(self, m, algorithm):
         """ Run dual gradient decent to optimize trajectories. """
         T = algorithm.T
         eta = algorithm.cur[m].eta
+        if self.cons_per_step and type(eta) in (int, float):
+            eta = np.ones(T) * eta
         step_mult = algorithm.cur[m].step_mult
         traj_info = algorithm.cur[m].traj_info
 
-        if type(algorithm) == AlgorithmMDGPS:
+        if isinstance(algorithm, AlgorithmMDGPS):
             # For MDGPS, constrain to previous NN linearization
             prev_traj_distr = algorithm.cur[m].pol_info.traj_distr()
         else:
@@ -40,56 +50,141 @@ class TrajOptLQRPython(TrajOpt):
             prev_traj_distr = algorithm.cur[m].traj_distr
 
         # Set KL-divergence step size (epsilon).
-        kl_step = T * algorithm.base_kl_step * step_mult
+        kl_step = algorithm.base_kl_step * step_mult
+        if not self.cons_per_step:
+            kl_step *= T
 
         # We assume at min_eta, kl_div > kl_step, opposite for max_eta.
-        min_eta = self._hyperparams['min_eta']
-        max_eta = self._hyperparams['max_eta']
+        if not self.cons_per_step:
+            min_eta = self._hyperparams['min_eta']
+            max_eta = self._hyperparams['max_eta']
+            LOGGER.debug("Running DGD for trajectory %d, eta: %f", m, eta)
+        else:
+            min_eta = np.ones(T) * self._hyperparams['min_eta']
+            max_eta = np.ones(T) * self._hyperparams['max_eta']
+            LOGGER.debug("Running DGD for trajectory %d, avg eta: %f", m,
+                         np.mean(eta[:-1]))
 
-        LOGGER.debug("Running DGD for trajectory %d, eta: %f", m, eta)
-        for itr in range(DGD_MAX_ITER):
-            LOGGER.debug("Iteration %i, bracket: (%.2e , %.2e , %.2e)",
-                    itr, min_eta, eta, max_eta)
+        max_itr = (DGD_MAX_LS_ITER if self.cons_per_step else
+                   DGD_MAX_ITER)
+        for itr in range(max_itr):
+            if not self.cons_per_step:
+                LOGGER.debug("Iteration %d, bracket: (%.2e , %.2e , %.2e)", itr,
+                             min_eta, eta, max_eta)
 
             # Run fwd/bwd pass, note that eta may be updated.
-            # NOTE: we can just ignore case when the new eta is larger.
-            traj_distr, eta = self.backward(prev_traj_distr, traj_info,
-                                                eta, algorithm, m)
-            new_mu, new_sigma = self.forward(traj_distr, traj_info)
-
             # Compute KL divergence constraint violation.
-            kl_div = traj_distr_kl(new_mu, new_sigma,
-                                   traj_distr, prev_traj_distr)
+            traj_distr, eta = self.backward(prev_traj_distr, traj_info,
+                                            eta, algorithm, m)
+
+            if not self._use_prev_distr:
+                new_mu, new_sigma = self.forward(traj_distr, traj_info)
+                kl_div = traj_distr_kl(
+                        new_mu, new_sigma, traj_distr, prev_traj_distr,
+                        tot=(not self.cons_per_step)
+                )
+            else:
+                prev_mu, prev_sigma = self.forward(prev_traj_distr, traj_info)
+                kl_div = traj_distr_kl_alt(
+                        prev_mu, prev_sigma, traj_distr, prev_traj_distr,
+                        tot=(not self.cons_per_step)
+                )
+
             con = kl_div - kl_step
 
             # Convergence check - constraint satisfaction.
-            if (abs(con) < 0.1*kl_step):
-                LOGGER.debug("KL: %f / %f, converged iteration %i",
-                        kl_div, kl_step, itr)
+            if self._conv_check(con, kl_step):
+                if not self.cons_per_step:
+                    LOGGER.debug("KL: %f / %f, converged iteration %d", kl_div,
+                                 kl_step, itr)
+                else:
+                    LOGGER.debug(
+                            "KL: %f / %f, converged iteration %d",
+                            np.mean(kl_div[:-1]), np.mean(kl_step[:-1]), itr
+                    )
                 break
 
-            # Choose new eta (bisect bracket or multiply by constant)
-            if con < 0: # Eta was too big.
-                max_eta = eta
-                geom = np.sqrt(min_eta*max_eta)  # Geometric mean.
-                new_eta = max(geom, 0.1*max_eta)
-                LOGGER.debug("KL: %f / %f, eta too big, new eta: %f",
-                        kl_div, kl_step, new_eta)
-            else: # Eta was too small.
-                min_eta = eta
-                geom = np.sqrt(min_eta*max_eta)  # Geometric mean.
-                new_eta = min(geom, 10.0*min_eta)
-                LOGGER.debug("KL: %f / %f, eta too small, new eta: %f",
-                        kl_div, kl_step, new_eta)
+            if not self.cons_per_step:
+                # Choose new eta (bisect bracket or multiply by constant)
+                if con < 0: # Eta was too big.
+                    max_eta = eta
+                    geom = np.sqrt(min_eta*max_eta)  # Geometric mean.
+                    new_eta = max(geom, 0.1*max_eta)
+                    LOGGER.debug("KL: %f / %f, eta too big, new eta: %f",
+                                 kl_div, kl_step, new_eta)
+                else: # Eta was too small.
+                    min_eta = eta
+                    geom = np.sqrt(min_eta*max_eta)  # Geometric mean.
+                    new_eta = min(geom, 10.0*min_eta)
+                    LOGGER.debug("KL: %f / %f, eta too small, new eta: %f",
+                                 kl_div, kl_step, new_eta)
 
-            # Logarithmic mean: log_mean(x,y) = (y - x)/(log(y) - log(x))
-            eta = new_eta
+                # Logarithmic mean: log_mean(x,y) = (y - x)/(log(y) - log(x))
+                eta = new_eta
+            else:
+                for t in range(T):
+                    if con[t] < 0:
+                        max_eta[t] = eta[t]
+                        geom = np.sqrt(min_eta[t]*max_eta[t])
+                        eta[t] = max(geom, 0.1*max_eta[t])
+                    else:
+                        min_eta[t] = eta[t]
+                        geom = np.sqrt(min_eta[t]*max_eta[t])
+                        eta[t] = min(geom, 10.0*min_eta[t])
+                if itr % 10 == 0:
+                    LOGGER.debug("avg KL: %f / %f, avg new eta: %f",
+                                 np.mean(kl_div[:-1]), np.mean(kl_step[:-1]),
+                                 np.mean(eta[:-1]))
 
-        if kl_div > kl_step and abs(kl_div - kl_step) > 0.1*kl_step:
+        if (self.cons_per_step and not self._conv_check(con, kl_step)):
+            m_b, v_b = np.zeros(T-1), np.zeros(T-1)
+
+            for itr in range(DGD_MAX_GD_ITER):
+                traj_distr, eta = self.backward(prev_traj_distr, traj_info,
+                                                eta, algorithm, m)
+
+                if not self._use_prev_distr:
+                    new_mu, new_sigma = self.forward(traj_distr, traj_info)
+                    kl_div = traj_distr_kl(
+                            new_mu, new_sigma, traj_distr, prev_traj_distr,
+                            tot=False
+                    )
+                else:
+                    prev_mu, prev_sigma = self.forward(prev_traj_distr,
+                                                       traj_info)
+                    kl_div = traj_distr_kl_alt(
+                            prev_mu, prev_sigma, traj_distr, prev_traj_distr,
+                            tot=False
+                    )
+
+                con = kl_div - kl_step
+                if self._conv_check(con, kl_step):
+                    LOGGER.debug(
+                            "KL: %f / %f, converged iteration %d",
+                            np.mean(kl_div[:-1]), np.mean(kl_step[:-1]), itr
+                    )
+                    break
+
+                m_b = (BETA1 * m_b + (1-BETA1) * con[:-1])
+                m_u = m_b / (1 - BETA1 ** (itr+1))
+                v_b = (BETA2 * v_b + (1-BETA2) * np.square(con[:-1]))
+                v_u = v_b / (1 - BETA2 ** (itr+1))
+                eta[:-1] = np.minimum(
+                        np.maximum(eta[:-1] + ALPHA * m_u / (np.sqrt(v_u) + EPS),
+                                   self._hyperparams['min_eta']),
+                        self._hyperparams['max_eta']
+                )
+
+                if itr % 10 == 0:
+                    LOGGER.debug("avg KL: %f / %f, avg new eta: %f",
+                                 np.mean(kl_div[:-1]), np.mean(kl_step[:-1]),
+                                 np.mean(eta[:-1]))
+
+        if (np.mean(kl_div) > np.mean(kl_step) and
+            not self._conv_check(con, kl_step)):
             LOGGER.warning(
-                "Final KL divergence after DGD convergence is too high."
+                    "Final KL divergence after DGD convergence is too high."
             )
-
         return traj_distr, eta
 
     def estimate_cost(self, traj_distr, traj_info):
@@ -189,7 +284,10 @@ class TrajOptLQRPython(TrajOpt):
         dU = prev_traj_distr.dU
         dX = prev_traj_distr.dX
 
-        traj_distr = prev_traj_distr.nans_like()
+        if self._update_in_bwd_pass:
+            traj_distr = prev_traj_distr.nans_like()
+        else:
+            traj_distr = prev_traj_distr.copy()
 
         # Store pol_wt if necessary
         if type(algorithm) == AlgorithmBADMM:
@@ -204,6 +302,8 @@ class TrajOptLQRPython(TrajOpt):
 
         # Non-SPD correction terms.
         del_ = self._hyperparams['del0']
+        if self.cons_per_step:
+            del_ = np.ones(T) * del_
         eta0 = eta
 
         # Run dynamic programming.
@@ -214,14 +314,23 @@ class TrajOptLQRPython(TrajOpt):
             # Allocate.
             Vxx = np.zeros((T, dX, dX))
             Vx = np.zeros((T, dX))
+            Qtt = np.zeros((T, dX+dU, dX+dU))
+            Qt = np.zeros((T, dX+dU))
 
-            fCm, fcv = algorithm.compute_costs(m, eta)
+            if not self._update_in_bwd_pass:
+                new_K, new_k = np.zeros((T, dU, dX)), np.zeros((T, dU))
+                new_pS = np.zeros((T, dU, dU))
+                new_ipS, new_cpS = np.zeros((T, dU, dU)), np.zeros((T, dU, dU))
+
+            fCm, fcv = algorithm.compute_costs(
+                    m, eta, augment=(not self.cons_per_step)
+            )
 
             # Compute state-action-state function at each time step.
             for t in range(T - 1, -1, -1):
                 # Add in the cost.
-                Qtt = fCm[t, :, :]  # (X+U) x (X+U)
-                Qt = fcv[t, :]  # (X+U) x 1
+                Qtt[t] = fCm[t, :, :]  # (X+U) x (X+U)
+                Qt[t] = fcv[t, :]  # (X+U) x 1
 
                 # Add in the value function from the next time step.
                 if t < T - 1:
@@ -229,61 +338,122 @@ class TrajOptLQRPython(TrajOpt):
                         multiplier = (pol_wt[t+1] + eta)/(pol_wt[t] + eta)
                     else:
                         multiplier = 1.0
-                    Qtt = Qtt + multiplier * \
+                    Qtt[t] += multiplier * \
                             Fm[t, :, :].T.dot(Vxx[t+1, :, :]).dot(Fm[t, :, :])
-                    Qt = Qt + multiplier * \
+                    Qt[t] += multiplier * \
                             Fm[t, :, :].T.dot(Vx[t+1, :] +
                                             Vxx[t+1, :, :].dot(fv[t, :]))
 
                 # Symmetrize quadratic component.
-                Qtt = 0.5 * (Qtt + Qtt.T)
+                Qtt[t] = 0.5 * (Qtt[t] + Qtt[t].T)
 
+                if not self.cons_per_step:
+                    inv_term = Qtt[t, idx_u, idx_u]
+                    k_term = Qt[t, idx_u]
+                    K_term = Qtt[t, idx_u, idx_x]
+                else:
+                    inv_term = (1.0 / eta[t]) * Qtt[t, idx_u, idx_u] + \
+                            prev_traj_distr.inv_pol_covar[t]
+                    k_term = (1.0 / eta[t]) * Qt[t, idx_u] - \
+                            prev_traj_distr.inv_pol_covar[t].dot(prev_traj_distr.k[t])
+                    K_term = (1.0 / eta[t]) * Qtt[t, idx_u, idx_x] - \
+                            prev_traj_distr.inv_pol_covar[t].dot(prev_traj_distr.K[t])
                 # Compute Cholesky decomposition of Q function action
                 # component.
                 try:
-                    U = sp.linalg.cholesky(Qtt[idx_u, idx_u])
+                    U = sp.linalg.cholesky(inv_term)
                     L = U.T
                 except LinAlgError as e:
                     # Error thrown when Qtt[idx_u, idx_u] is not
                     # symmetric positive definite.
                     LOGGER.debug('LinAlgError: %s', e)
-                    fail = True
+                    fail = t if self.cons_per_step else True
                     break
 
-                # Store conditional covariance, inverse, and Cholesky.
-                traj_distr.inv_pol_covar[t, :, :] = Qtt[idx_u, idx_u]
-                traj_distr.pol_covar[t, :, :] = sp.linalg.solve_triangular(
-                    U, sp.linalg.solve_triangular(L, np.eye(dU), lower=True)
-                )
-                traj_distr.chol_pol_covar[t, :, :] = sp.linalg.cholesky(
-                    traj_distr.pol_covar[t, :, :]
-                )
+                if self._hyperparams['update_in_bwd_pass']:
+                    # Store conditional covariance, inverse, and Cholesky.
+                    traj_distr.inv_pol_covar[t, :, :] = inv_term
+                    traj_distr.pol_covar[t, :, :] = sp.linalg.solve_triangular(
+                        U, sp.linalg.solve_triangular(L, np.eye(dU), lower=True)
+                    )
+                    traj_distr.chol_pol_covar[t, :, :] = sp.linalg.cholesky(
+                        traj_distr.pol_covar[t, :, :]
+                    )
 
-                # Compute mean terms.
-                traj_distr.k[t, :] = -sp.linalg.solve_triangular(
-                    U, sp.linalg.solve_triangular(L, Qt[idx_u], lower=True)
-                )
-                traj_distr.K[t, :, :] = -sp.linalg.solve_triangular(
-                    U, sp.linalg.solve_triangular(L, Qtt[idx_u, idx_x],
-                                                  lower=True)
-                )
+                    # Compute mean terms.
+                    traj_distr.k[t, :] = -sp.linalg.solve_triangular(
+                        U, sp.linalg.solve_triangular(L, k_term, lower=True)
+                    )
+                    traj_distr.K[t, :, :] = -sp.linalg.solve_triangular(
+                        U, sp.linalg.solve_triangular(L, K_term, lower=True)
+                    )
+                else:
+                    # Store conditional covariance, inverse, and Cholesky.
+                    new_ipS[t, :, :] = inv_term
+                    new_pS[t, :, :] = sp.linalg.solve_triangular(
+                        U, sp.linalg.solve_triangular(L, np.eye(dU), lower=True)
+                    )
+                    new_cpS[t, :, :] = sp.linalg.cholesky(
+                        new_pS[t, :, :]
+                    )
+
+                    # Compute mean terms.
+                    new_k[t, :] = -sp.linalg.solve_triangular(
+                        U, sp.linalg.solve_triangular(L, k_term, lower=True)
+                    )
+                    new_K[t, :, :] = -sp.linalg.solve_triangular(
+                        U, sp.linalg.solve_triangular(L, K_term, lower=True)
+                    )
 
                 # Compute value function.
-                Vxx[t, :, :] = Qtt[idx_x, idx_x] + \
-                        Qtt[idx_x, idx_u].dot(traj_distr.K[t, :, :])
-                Vx[t, :] = Qt[idx_x] + Qtt[idx_x, idx_u].dot(traj_distr.k[t, :])
+                if (self.cons_per_step or
+                    not self._hyperparams['update_in_bwd_pass']):
+                    Vxx[t, :, :] = Qtt[t, idx_x, idx_x] + \
+                            traj_distr.K[t].T.dot(Qtt[t, idx_u, idx_u]).dot(traj_distr.K[t]) + \
+                            (2 * Qtt[t, idx_x, idx_u]).dot(traj_distr.K[t])
+                    Vx[t, :] = Qt[t, idx_x].T + \
+                            Qt[t, idx_u].T.dot(traj_distr.K[t]) + \
+                            traj_distr.k[t].T.dot(Qtt[t, idx_u, idx_u]).dot(traj_distr.K[t]) + \
+                            Qtt[t, idx_x, idx_u].dot(traj_distr.k[t])
+                else:
+                    Vxx[t, :, :] = Qtt[t, idx_x, idx_x] + \
+                            Qtt[t, idx_x, idx_u].dot(traj_distr.K[t, :, :])
+                    Vx[t, :] = Qt[t, idx_x] + \
+                            Qtt[t, idx_x, idx_u].dot(traj_distr.k[t, :])
                 Vxx[t, :, :] = 0.5 * (Vxx[t, :, :] + Vxx[t, :, :].T)
+
+            if not self._hyperparams['update_in_bwd_pass']:
+                traj_distr.K, traj_distr.k = new_K, new_k
+                traj_distr.pol_covar = new_pS
+                traj_distr.inv_pol_covar = new_ipS
+                traj_distr.chol_pol_covar = new_cpS
 
             # Increment eta on non-SPD Q-function.
             if fail:
-                old_eta = eta
-                eta = eta0 + del_
-                LOGGER.debug('Increasing eta: %f -> %f', old_eta, eta)
-                del_ *= 2  # Increase del_ exponentially on failure.
-                if eta >= 1e16:
+                if not self.cons_per_step:
+                    old_eta = eta
+                    eta = eta0 + del_
+                    LOGGER.debug('Increasing eta: %f -> %f', old_eta, eta)
+                    del_ *= 2  # Increase del_ exponentially on failure.
+                else:
+                    old_eta = eta[fail]
+                    eta[fail] = eta0[fail] + del_[fail]
+                    LOGGER.debug('Increasing eta %d: %f -> %f',
+                                 fail, old_eta, eta[fail])
+                    del_[fail] *= 2  # Increase del_ exponentially on failure.
+                if self.cons_per_step:
+                    fail_check = (eta[fail] >= 1e16)
+                else:
+                    fail_check = (eta >= 1e16)
+                if fail_check:
                     if np.any(np.isnan(Fm)) or np.any(np.isnan(fv)):
                         raise ValueError('NaNs encountered in dynamics!')
                     raise ValueError('Failed to find PD solution even for very \
                             large eta (check that dynamics and cost are \
                             reasonably well conditioned)!')
         return traj_distr, eta
+
+    def _conv_check(self, con, kl_step):
+        if self.cons_per_step:
+            return all([abs(con[t]) < (0.1*kl_step[t]) for t in range(con.size)])
+        return abs(con) < 0.1 * kl_step

--- a/python/gps/algorithm/traj_opt/traj_opt_lqr_python.py
+++ b/python/gps/algorithm/traj_opt/traj_opt_lqr_python.py
@@ -454,6 +454,7 @@ class TrajOptLQRPython(TrajOpt):
         return traj_distr, eta
 
     def _conv_check(self, con, kl_step):
+        """Function that checks whether dual gradient descent has converged."""
         if self.cons_per_step:
             return all([abs(con[t]) < (0.1*kl_step[t]) for t in range(con.size)])
         return abs(con) < 0.1 * kl_step

--- a/python/gps/algorithm/traj_opt/traj_opt_pi2.py
+++ b/python/gps/algorithm/traj_opt/traj_opt_pi2.py
@@ -10,6 +10,7 @@ References:
     In AAAI, 2010.
  """
 import copy
+import logging
 import numpy as np
 import scipy as sp
 
@@ -19,8 +20,9 @@ from scipy.optimize import minimize
 from gps.algorithm.traj_opt.config import TRAJ_OPT_PI2
 from gps.algorithm.traj_opt.traj_opt import TrajOpt
 
+LOGGER = logging.getLogger(__name__)
 
-class TrajOptPi2(TrajOpt):
+class TrajOptPI2(TrajOpt):
     """ PI2 trajectory optimization.
     Hyperparameters:
         kl_threshold: KL-divergence threshold between old and new policies.
@@ -39,7 +41,8 @@ class TrajOptPi2(TrajOpt):
         self._covariance_damping = self._hyperparams['covariance_damping']
         self._min_temperature = self._hyperparams['min_temperature']
     
-    def update(self, m, algorithm):  
+    def update(self, m, algorithm, use_lqr_actions=False,
+               fixed_eta=None, use_fixed_eta=False, costs=None):
         """
         Perform optimization of the feedforward controls of time-varying
         linear-Gaussian controllers with PI2. 
@@ -50,34 +53,48 @@ class TrajOptPi2(TrajOpt):
             traj_distr: Updated linear-Gaussian controller.
         """
         # We only use the scalar costs.      
-        costs = algorithm.cur[m].cs
+        if costs is None:
+            costs = algorithm.cur[m].cs
 
         # Get sampled controls, states and old trajectory distribution.
         cur_data = algorithm.cur[m].sample_list                
         prev_traj_distr = algorithm.cur[m].traj_distr
         X = cur_data.get_X()
-        U = cur_data.get_U()        
+        U = cur_data.get_U()
+        noise = cur_data.get_noise()
         T = prev_traj_distr.T
 
         # We only optimize feedforward controls with PI2. Subtract the feedback
         # part from the sampled controls using feedback gain matrix and states.       
-        ffw_controls = np.zeros(U.shape)        
-        for i in xrange(len(cur_data)):
-            ffw_controls[i] = [U[i, t] - prev_traj_distr.K[t].dot(X[i, t]) 
-                               for t in xrange(T)]
+        ffw_controls = np.zeros(U.shape)
+        if use_lqr_actions:
+            for i in xrange(len(cur_data)):
+                U_lqr = [prev_traj_distr.K[t].dot(X[i, t]) + prev_traj_distr.k[t] +
+                         prev_traj_distr.chol_pol_covar[t].T.dot(noise[i, t])
+                         for t in xrange(T)]
+                ffw_controls[i] = [U_lqr[t] - prev_traj_distr.K[t].dot(X[i, t])
+                                   for t in xrange(T)]
+        else:
+            for i in xrange(len(cur_data)):
+                ffw_controls[i] = [U[i, t] - prev_traj_distr.K[t].dot(X[i, t])
+                                   for t in xrange(T)]
 
         # Copy feedback gain matrix from the old trajectory distribution.                       
         traj_distr = prev_traj_distr.nans_like()
         traj_distr.K = prev_traj_distr.K
 
         # Optimize feedforward controls and covariances with PI2.
-        (traj_distr.k, traj_distr.pol_covar, traj_distr.inv_pol_covar,
-         traj_distr.chol_pol_covar) = self.update_pi2(
-            ffw_controls, costs, prev_traj_distr.k, prev_traj_distr.pol_covar)
+        k, pS, ipS, cpS, eta = self.update_pi2(
+            ffw_controls, costs, prev_traj_distr.k, prev_traj_distr.pol_covar,
+            fixed_eta, use_fixed_eta
+        )
+        traj_distr.k, traj_distr.pol_covar = k, pS
+        traj_distr.inv_pol_covar, traj_distr.chol_pol_covar = ipS, cpS
 
-        return traj_distr, None
+        return traj_distr, eta
 
-    def update_pi2(self, samples, costs, mean_old, cov_old):        
+    def update_pi2(self, samples, costs, mean_old, cov_old,
+                   fixed_eta=None, use_fixed_eta=False):
         """
         Perform optimization with PI2. Computes new mean and covariance matrices
         of the policy parameters given policy samples and their costs.
@@ -101,51 +118,71 @@ class TrajOptPi2(TrajOpt):
 
         # Iterate over time steps.
         T = samples.shape[1]
-        for t in xrange(T):     
+        etas = np.zeros(T)
 
-            # Compute cost-to-go for each time step for each sample.           
-            cost_to_go = np.sum(costs[:, t:T], axis=1)
-            
-            # Normalize costs.
-            min_cost_to_go = np.min(cost_to_go)
-            max_cost_to_go = np.max(cost_to_go)
-            cost_to_go = (cost_to_go - min_cost_to_go) / (
-                max_cost_to_go - min_cost_to_go + 0.00001)
+        del_ = self._hyperparams['del0']
+        if self._hyperparams['pi2_cons_per_step']:
+            del_ = np.ones(T) * del_
 
-            # Perform REPS-like optimization of the temperature eta.
-            res = minimize(self.kl_dual, 1.0, bounds=((self._min_temperature, 
-                None),), args=(self._kl_threshold, cost_to_go))
-            eta = res.x
+        fail = True
+        while fail:
+            fail = False
+            for t in xrange(T):
 
-            # Compute probabilities of each sample.
-            exp_cost = np.exp(-cost_to_go / eta)
-            prob =  exp_cost / np.sum(exp_cost)
+                # Compute cost-to-go for each time step for each sample.
+                cost_to_go = np.sum(costs[:, t:T], axis=1)
 
-            # Update policy mean with weighted max-likelihood.
-            mean_new[t] = np.sum(prob[:, np.newaxis] * samples[:, t], axis=0)
+                if use_fixed_eta:
+                    eta = (fixed_eta[t] if isinstance(fixed_eta, np.ndarray)
+                           else fixed_eta)
+                else:
+                    # Perform REPS-like optimization of the temperature eta.
+                    res = minimize(self.kl_dual, 10.0,
+                                   bounds=((self._min_temperature, None),),
+                                   args=(self._kl_threshold, cost_to_go))
+                    etas[t] = res.x
+                    eta = res.x
 
-            # Update policy covariance with weighted max-likelihood.
-            for i in xrange(samples.shape[0]):
-                mean_diff = samples[i, t] - mean_new[t]
-                mean_diff = np.reshape(mean_diff, (len(mean_diff), 1))                
-                cov_new[t] += prob[i] * np.dot(mean_diff, mean_diff.T)
-            
-            # If covariance damping is enabled, compute covariance as multiple
-            # of the old covariance. The multiplier is first fitted using 
-            # max-likelihood and then taken to the power (1/covariance_damping).
-            if(self._covariance_damping is not None 
-               and self._covariance_damping > 0.0):
-                
-                mult = np.trace(np.dot(sp.linalg.inv(cov_old[t]), 
-                    cov_new[t])) / len(cov_old[t])
-                mult = np.power(mult, 1 / self._covariance_damping)
-                cov_new[t] = mult * cov_old[t]
+                exponent = -cost_to_go
 
-            # Compute covariance inverse and cholesky decomposition.
-            inv_cov_new[t] = sp.linalg.inv(cov_new[t])
-            chol_cov_new[t] = sp.linalg.cholesky(cov_new[t])
+                exp_cost = np.exp((exponent - np.max(exponent)) / eta)
+                prob = exp_cost / np.sum(exp_cost)
 
-        return mean_new, cov_new, inv_cov_new, chol_cov_new
+                # Update policy mean with weighted max-likelihood.
+                mean_new[t] = np.sum(prob[:, np.newaxis] * samples[:, t], axis=0)
+
+                # Update policy covariance with weighted max-likelihood.
+                for i in xrange(samples.shape[0]):
+                    mean_diff = samples[i, t] - mean_new[t]
+                    mean_diff = np.reshape(mean_diff, (len(mean_diff), 1))
+                    cov_new[t] += prob[i] * np.dot(mean_diff, mean_diff.T)
+
+                # If covariance damping is enabled, compute covariance as multiple
+                # of the old covariance. The multiplier is first fitted using
+                # max-likelihood and then taken to the power (1/covariance_damping).
+                if(self._covariance_damping is not None
+                   and self._covariance_damping > 0.0):
+
+                    mult = np.trace(np.dot(sp.linalg.inv(cov_old[t]),
+                        cov_new[t])) / len(cov_old[t])
+                    mult = np.power(mult, 1 / self._covariance_damping)
+                    cov_new[t] = mult * cov_old[t]
+
+                # Compute covariance inverse and cholesky decomposition.
+                try:
+                    inv_cov_new[t] = sp.linalg.inv(cov_new[t])
+                    chol_cov_new[t] = sp.linalg.cholesky(cov_new[t])
+                except LinAlgError:
+                    fail = True
+                    old_eta = eta
+                    eta = fixed_eta if use_fixed_eta else etas
+                    eta[t] += del_[t]
+                    LOGGER.debug('Increasing eta %d: %f -> %f', t, old_eta, eta[t])
+                    del_[t] *= 2
+                    if eta[t] >= 1e16:
+                        raise ValueError
+
+        return mean_new, cov_new, inv_cov_new, chol_cov_new, etas
 
     def kl_dual(self, eta, kl_threshold, costs):
         """
@@ -159,5 +196,8 @@ class TrajOptPi2(TrajOpt):
         Returns:
             Value of the dual function.
         """
-        return eta * kl_threshold + eta * np.log((1.0/len(costs)) * 
-               np.sum(np.exp(-costs/eta)))
+        max_costs = np.max(-costs)
+        exponent = -costs - max_costs
+        return (eta * kl_threshold + max_costs
+                + eta * np.log((1.0 / len(costs)) *
+                np.sum(np.exp(exponent / eta))))

--- a/python/gps/algorithm/traj_opt/traj_opt_pi2.py
+++ b/python/gps/algorithm/traj_opt/traj_opt_pi2.py
@@ -49,6 +49,11 @@ class TrajOptPI2(TrajOpt):
         Args:
             m: Current condition number.
             algorithm: Currently used algorithm.
+            use_lqr_actions: Whether or not to compute actions from LQR-updated
+                controller.
+            fixed_eta: Fixed value of eta to use if use_fixed_eta is True.
+            use_fixed_eta: Whether to use fixed_eta or compute using KL dual.
+            costs: Costs to update with, defaults to sampled costs.
         Returns:
             traj_distr: Updated linear-Gaussian controller.
         """
@@ -105,6 +110,8 @@ class TrajOptPI2(TrajOpt):
                    [num_samples x num_timesteps]
             mean_old: Old policy mean.
             cov_old: Old policy covariance.            
+            fixed_eta: Fixed value of eta to use if use_fixed_eta is True.
+            use_fixed_eta: Whether to use fixed_eta or compute using KL dual.
         Returns:
             mean_new: New policy mean.
             cov_new: New policy covariance.

--- a/python/gps/algorithm/traj_opt/traj_opt_pi2.py
+++ b/python/gps/algorithm/traj_opt/traj_opt_pi2.py
@@ -66,13 +66,13 @@ class TrajOptPI2(TrajOpt):
         prev_traj_distr = algorithm.cur[m].traj_distr
         X = cur_data.get_X()
         U = cur_data.get_U()
-        noise = cur_data.get_noise()
         T = prev_traj_distr.T
 
         # We only optimize feedforward controls with PI2. Subtract the feedback
         # part from the sampled controls using feedback gain matrix and states.       
         ffw_controls = np.zeros(U.shape)
         if use_lqr_actions:
+            noise = cur_data.get_noise()
             for i in xrange(len(cur_data)):
                 U_lqr = [prev_traj_distr.K[t].dot(X[i, t]) + prev_traj_distr.k[t] +
                          prev_traj_distr.chol_pol_covar[t].T.dot(noise[i, t])

--- a/python/gps/algorithm/traj_opt/traj_opt_pilqr.py
+++ b/python/gps/algorithm/traj_opt/traj_opt_pilqr.py
@@ -1,0 +1,60 @@
+""" This file defines code for PILQR. """
+import logging
+import copy
+
+import numpy as np
+from numpy.linalg import LinAlgError
+import scipy as sp
+
+from gps.algorithm.traj_opt.config import TRAJ_OPT_LQR, TRAJ_OPT_PI2, \
+        TRAJ_OPT_PILQR
+from gps.algorithm.traj_opt.traj_opt_lqr_python import TrajOptLQRPython
+from gps.algorithm.traj_opt.traj_opt_utils import  approximated_cost
+
+from gps.algorithm.traj_opt.traj_opt_pi2 import TrajOptPI2
+from gps.algorithm.algorithm_badmm import AlgorithmBADMM
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TrajOptPILQR(TrajOptLQRPython):
+    """ PILQR trajectory optimization. """
+    def __init__(self, hyperparams):
+        self.config_lqr = copy.deepcopy(TRAJ_OPT_LQR)
+        self.config_lqr.update(TRAJ_OPT_PILQR)
+        self.config_lqr.update(hyperparams)
+
+        self.config_pi2 = copy.deepcopy(TRAJ_OPT_PI2)
+        self.config_pi2.update(hyperparams)
+
+        TrajOptLQRPython.__init__(self, self.config_lqr)
+
+        self.traj_opt_pi2 = TrajOptPI2(self.config_pi2)
+
+
+    def update(self, m, algorithm):
+        traj_distr, eta = TrajOptLQRPython.update(self, m, algorithm)
+        prev_traj_distr = algorithm.cur[m].traj_distr
+        traj_info = algorithm.cur[m].traj_info
+
+        algorithm.cur[m].traj_distr = traj_distr
+
+        self._hyperparams = self.config_pi2
+        mu, c_approx = approximated_cost(
+                algorithm.cur[m].sample_list, prev_traj_distr, traj_info
+        )
+        residual_cost = algorithm.cur[m].cs - c_approx
+        _, eta_pi2 = self.traj_opt_pi2.update(
+                m, algorithm, use_lqr_actions=True, use_fixed_eta=False
+        )
+
+        pi2_traj_distr, _ = self.traj_opt_pi2.update(
+                m, algorithm, use_lqr_actions=True,
+                fixed_eta=eta_pi2, use_fixed_eta=True, costs=residual_cost
+        )
+
+        self._hyperparams = self.config_lqr
+        algorithm.cur[m].traj_distr = prev_traj_distr
+
+        return pi2_traj_distr, eta

--- a/python/gps/algorithm/traj_opt/traj_opt_utils.py
+++ b/python/gps/algorithm/traj_opt/traj_opt_utils.py
@@ -10,9 +10,13 @@ LOGGER = logging.getLogger(__name__)
 
 # Constants used in TrajOptLQR.
 DGD_MAX_ITER = 50
+DGD_MAX_LS_ITER = 20
+DGD_MAX_GD_ITER = 200
+
+ALPHA, BETA1, BETA2, EPS = 0.005, 0.9, 0.999, 1e-8  # Adam parameters
 
 
-def traj_distr_kl(new_mu, new_sigma, new_traj_distr, prev_traj_distr):
+def traj_distr_kl(new_mu, new_sigma, new_traj_distr, prev_traj_distr, tot=True):
     """
     Compute KL divergence between new and previous trajectory
     distributions.
@@ -83,4 +87,84 @@ def traj_distr_kl(new_mu, new_sigma, new_traj_distr, prev_traj_distr):
         )
 
     # Add up divergences across time to get total divergence.
-    return np.sum(kl_div)
+    return np.sum(kl_div) if tot else kl_div
+
+
+def traj_distr_kl_alt(new_mu, new_sigma, new_traj_distr, prev_traj_distr, tot=True):
+    T, dX, dU = new_mu.shape[0], new_traj_distr.dX, new_traj_distr.dU
+    kl_div = np.zeros(T)
+
+    for t in range(T):
+        K_prev = prev_traj_distr.K[t, :, :]
+        K_new = new_traj_distr.K[t, :, :]
+
+        k_prev = prev_traj_distr.k[t, :]
+        k_new = new_traj_distr.k[t, :]
+
+        sig_prev = prev_traj_distr.pol_covar[t, :, :]
+        sig_new = new_traj_distr.pol_covar[t, :, :]
+
+        chol_prev = prev_traj_distr.chol_pol_covar[t, :, :]
+        chol_new = new_traj_distr.chol_pol_covar[t, :, :]
+
+        inv_prev = prev_traj_distr.inv_pol_covar[t, :, :]
+        inv_new = new_traj_distr.inv_pol_covar[t, :, :]
+
+        logdet_prev = 2 * sum(np.log(np.diag(chol_prev)))
+        logdet_new = 2 * sum(np.log(np.diag(chol_new)))
+
+        K_diff, k_diff = K_prev - K_new, k_prev - k_new
+        mu, sigma = new_mu[t, :dX], new_sigma[t, :dX, :dX]
+
+        kl_div[t] = max(
+                0,
+                0.5 * (logdet_prev - logdet_new - new_traj_distr.dU +
+                       np.sum(np.diag(inv_prev.dot(sig_new))) +
+                       k_diff.T.dot(inv_prev).dot(k_diff) +
+                       mu.T.dot(K_diff.T).dot(inv_prev).dot(K_diff).dot(mu) +
+                       np.sum(np.diag(K_diff.T.dot(inv_prev).dot(K_diff).dot(sigma))) +
+                       2 * k_diff.T.dot(inv_prev).dot(K_diff).dot(mu))
+        )
+
+    return np.sum(kl_div) if tot else kl_div
+
+
+def approximated_cost(sample_list, traj_distr, traj_info):
+    T = traj_distr.T
+    N = len(sample_list)
+    dU = traj_distr.dU
+    dX = traj_distr.dX
+    noise = sample_list.get_noise()
+
+    # Constants.
+    idx_x = slice(dX)
+    mu_all = np.zeros((N, T, dX+dU))
+
+    # Pull out dynamics.
+    Fm = traj_info.dynamics.Fm
+    fv = traj_info.dynamics.fv
+    dyn_covar = traj_info.dynamics.dyn_covar
+
+    for i in range(N):
+        mu = np.zeros((T, dX+dU))
+        mu[0, idx_x] = traj_info.x0mu
+        for t in range(T):
+            mu[t, :] = np.hstack([
+                mu[t, idx_x],
+                (traj_distr.K[t, :, :].dot(mu[t, idx_x]) + traj_distr.k[t, :]
+                 + traj_distr.chol_pol_covar[t].T.dot(noise[i, t]))
+            ])
+            if t < T - 1:
+                mu[t+1, idx_x] = Fm[t, :, :].dot(mu[t, :]) + fv[t, :]
+        mu_all[i, :, :] = mu
+
+    # Compute cost.
+    predicted_cost = np.zeros((N, T))
+
+    for i in range(N):
+        for t in range(T):
+            predicted_cost[i, t] = traj_info.cc[t] + \
+                    0.5 * mu_all[i,t,:].T.dot(traj_info.Cm[t, :, :]).dot(mu_all[i,t,:]) + \
+                    mu_all[i,t,:].T.dot(traj_info.cv[t, :])
+
+    return mu_all, predicted_cost

--- a/python/gps/algorithm/traj_opt/traj_opt_utils.py
+++ b/python/gps/algorithm/traj_opt/traj_opt_utils.py
@@ -27,6 +27,7 @@ def traj_distr_kl(new_mu, new_sigma, new_traj_distr, prev_traj_distr, tot=True):
             distribution.
         prev_traj_distr: A linear Gaussian policy object, previous
             distribution.
+        tot: Whether or not to sum KL across all time steps.
     Returns:
         kl_div: The KL divergence between the new and previous
             trajectories.
@@ -91,6 +92,11 @@ def traj_distr_kl(new_mu, new_sigma, new_traj_distr, prev_traj_distr, tot=True):
 
 
 def traj_distr_kl_alt(new_mu, new_sigma, new_traj_distr, prev_traj_distr, tot=True):
+    """
+    This function computes the same quantity as the function above.
+    However, it is easier to modify and understand this function, i.e.,
+    passing in a different mu and sigma to this function will behave properly.
+    """
     T, dX, dU = new_mu.shape[0], new_traj_distr.dX, new_traj_distr.dU
     kl_div = np.zeros(T)
 
@@ -130,6 +136,17 @@ def traj_distr_kl_alt(new_mu, new_sigma, new_traj_distr, prev_traj_distr, tot=Tr
 
 
 def approximated_cost(sample_list, traj_distr, traj_info):
+    """
+    This function gives the LQR estimate of the cost function given the noise
+    experienced along each sample in sample_list.
+    Args:
+        sample_list: List of samples to extract noise from.
+        traj_distr: LQR controller to roll forward.
+        traj_info: Used to obtain dynamics estimate to simulate trajectories.
+    Returns:
+        mu_all: Trajectory means corresponding to each sample in sample_list.
+        predicted_cost: LQR estimates of cost of each sample in sample_list.
+    """
     T = traj_distr.T
     N = len(sample_list)
     dU = traj_distr.dU

--- a/python/gps/gui/gps_training_gui.py
+++ b/python/gps/gui/gps_training_gui.py
@@ -325,7 +325,7 @@ class GPSTrainingGUI(object):
             itr_data = '%3d | %8.2f' % (itr, avg_cost)
         for m in range(algorithm.M):
             cost = costs[m]
-            step = algorithm.prev[m].step_mult * algorithm.base_kl_step
+            step = np.mean(algorithm.prev[m].step_mult * algorithm.base_kl_step)
             entropy = 2*np.sum(np.log(np.diagonal(algorithm.prev[m].traj_distr.chol_pol_covar,
                     axis1=1, axis2=2)))
             itr_data += ' | %8.2f %8.2f %8.2f' % (cost, step, entropy)

--- a/python/gps/sample/sample_list.py
+++ b/python/gps/sample/sample_list.py
@@ -4,6 +4,8 @@ import logging
 
 import numpy as np
 
+from gps.proto.gps_pb2 import NOISE
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -24,6 +26,12 @@ class SampleList(object):
         if idx is None:
             idx = range(len(self._samples))
         return np.asarray([self._samples[i].get_U() for i in idx])
+
+    def get_noise(self, idx=None):
+        """ Returns N x T x dU numpy array of noise generated during rollouts. """
+        if idx is None:
+            idx = range(len(self._samples))
+        return np.asarray([self._samples[i].get(NOISE) for i in idx])
 
     def get_obs(self, idx=None):
         """ Returns N x T x dO numpy array of features. """

--- a/src/proto/gps.proto
+++ b/src/proto/gps.proto
@@ -23,7 +23,8 @@ enum SampleType {
   IMAGE_FEAT = 16;
   END_EFFECTOR_POINTS_NO_TARGET = 17;
   END_EFFECTOR_POINT_VELOCITIES_NO_TARGET = 18;
-  TOTAL_DATA_TYPES = 19;
+  NOISE = 19;
+  TOTAL_DATA_TYPES = 20;
 }
 
 // Message containing the data for a single sample.


### PR DESCRIPTION
This PR implements the PILQR algorithm as described in [1] as well as the MDGPS extension. Three experiments are provided: a pointmass example with discontinuous costs, as well as the gripper pusher trajectory optimization and door opening policy optimization experiments from [1].

The main contributions are as follows:

- Algorithm files `algorithm_mdgps_pilqr.py`, `algorithm_traj_opt_pilqr.py`, and `traj_opt_pilqr.py`. In addition, `traj_opt_lqr_python.py` and `traj_opt_pi2.py` have been modified heavily to support the algorithm detailed in [1].
- Experiment files provided in the `mjc_disc_cost_example`, `mjc_gripper_pusher`, and `mjc_door_opening` experiment directories along with the MuJoCo XML files.
- Supporting files for new cost functions (note that there is one TODO left here that I believe is out of the scope of this PR), TensorFlow network construction, and KL-divergence computation.

There are various other minor changes that should be relatively self-explanatory given the diffs below, mostly cosmetic and some functional.

Huge thanks to collaborators @Lolu28 and @ychebotar for helping to get this out the door.

[1] Y. Chebotar, et. al. "Combining model-based and model-free updates for trajectory-centric reinforcement learning." arXiv pre-print arXiv:1703.03078.