### PR TITLE
fix axis_limits error in python/gps/gui/gps_training_gui.py

### DIFF
--- a/python/gps/gui/gps_training_gui.py
+++ b/python/gps/gui/gps_training_gui.py
@@ -366,7 +366,7 @@ class GPSTrainingGUI(object):
         all_eept = np.empty((0, 3))
         sample_lists = traj_sample_lists
         if pol_sample_lists:
-            sample_lists += traj_sample_lists
+            sample_lists += pol_sample_lists
         for sample_list in sample_lists:
             for sample in sample_list.get_samples():
                 ee_pt = sample.get(END_EFFECTOR_POINTS)


### PR DESCRIPTION
there is an error in calculate the axis limits for GUI plotting which do not consider the policy sample

    def _calculate_3d_axis_limits(self, traj_sample_lists, pol_sample_lists):
        ...
        sample_lists = traj_sample_lists
        if pol_sample_lists:
             sample_lists += pol_sample_lists
             # sample_lists += traj_sample_lists    # original code
         ....
