### PR TITLE
Infer dim_input in tf_model_example

### DIFF
--- a/python/gps/algorithm/policy_opt/tf_model_example.py
+++ b/python/gps/algorithm/policy_opt/tf_model_example.py
@@ -119,7 +119,7 @@ def multi_modal_network(dim_input=27, dim_output=7, batch_size=25, network_confi
         else:
             x_idx = x_idx + list(range(i, i+dim))
         i += dim
-
+    dim_input = i
     nn_input, action, precision = get_input_layer(dim_input, dim_output)
 
     state_input = nn_input[:, 0:x_idx[-1]+1]
@@ -193,7 +193,7 @@ def multi_modal_network_fp(dim_input=27, dim_output=7, batch_size=25, network_co
         else:
             x_idx = x_idx + list(range(i, i+dim))
         i += dim
-
+    dim_input = i
     nn_input, action, precision = get_input_layer(dim_input, dim_output)
 
     state_input = nn_input[:, 0:x_idx[-1]+1]


### PR DESCRIPTION
I found this fixed an error that was otherwise raised by get_input_layer in my attempt at a box2d_arm_img experiment.

I am not sure where in the initialization process of the experiment the dim_input is passed along, but found out that it was zero here. Adding this 1 line per multi_modal_network fixes the issue by inferring dim_input from the given obs_include hyperparameter.